### PR TITLE
Don't unmount entire plugin manager tree on remove

### DIFF
--- a/components/engine/plugin/backend_linux.go
+++ b/components/engine/plugin/backend_linux.go
@@ -633,8 +633,8 @@ func (pm *Manager) Remove(name string, config *types.PluginRmConfig) error {
 	id := p.GetID()
 	pm.config.Store.Remove(p)
 	pluginDir := filepath.Join(pm.config.Root, id)
-	if err := recursiveUnmount(pm.config.Root); err != nil {
-		logrus.WithField("dir", pm.config.Root).WithField("id", id).Warn(err)
+	if err := recursiveUnmount(pluginDir); err != nil {
+		logrus.WithField("dir", pluginDir).WithField("id", id).Warn(err)
 	}
 	if err := os.RemoveAll(pluginDir); err != nil {
 		logrus.Warnf("unable to remove %q from plugin remove: %v", pluginDir, err)


### PR DESCRIPTION
This was mistakenly unmounting everything under `plugins/*` instead of
just `plugins/<id>/*` anytime a plugin is removed.

Signed-off-by: Brian Goff <cpuguy83@gmail.com>
(cherry picked from commit db5f31732a9868c1e9e4f9a49be70b794ff82d4f)

-- 
Cherry pick of moby/moby#33422