### PR TITLE
Do not clear swarm directory at the begining of swarm init and swarm …

### DIFF
--- a/components/engine/daemon/cluster/swarm.go
+++ b/components/engine/daemon/cluster/swarm.go
@@ -88,10 +88,6 @@ func (c *Cluster) Init(req types.InitRequest) (string, error) {
 		}
 	}
 
-	if !req.ForceNewCluster {
-		clearPersistentState(c.root)
-	}
-
 	nr, err := c.newNodeRunner(nodeStartConfig{
 		forceNewCluster: req.ForceNewCluster,
 		autolock:        req.AutoLockManagers,
@@ -109,15 +105,13 @@ func (c *Cluster) Init(req types.InitRequest) (string, error) {
 	c.mu.Unlock()
 
 	if err := <-nr.Ready(); err != nil {
+		c.mu.Lock()
+		c.nr = nil
+		c.mu.Unlock()
 		if !req.ForceNewCluster { // if failure on first attempt don't keep state
 			if err := clearPersistentState(c.root); err != nil {
 				return "", err
 			}
-		}
-		if err != nil {
-			c.mu.Lock()
-			c.nr = nil
-			c.mu.Unlock()
 		}
 		return "", err
 	}
@@ -166,8 +160,6 @@ func (c *Cluster) Join(req types.JoinRequest) error {
 		return err
 	}
 
-	clearPersistentState(c.root)
-
 	nr, err := c.newNodeRunner(nodeStartConfig{
 		RemoteAddr:    req.RemoteAddrs[0],
 		ListenAddr:    net.JoinHostPort(listenHost, listenPort),
@@ -193,6 +185,9 @@ func (c *Cluster) Join(req types.JoinRequest) error {
 			c.mu.Lock()
 			c.nr = nil
 			c.mu.Unlock()
+			if err := clearPersistentState(c.root); err != nil {
+				return err
+			}
 		}
 		return err
 	}


### PR DESCRIPTION
…join now.

However, do clear the directory if init or join fails, because we don't
want to leave it in a half-finished state.

Signed-off-by: Ying Li <ying.li@docker.com>
(cherry picked from commit bf3e9293a66c77a2fddf4e691222898846b4af9f)

---

Cherry pick of moby/moby#33341
