### PR TITLE
Add raspbian deb packages

### DIFF
--- a/components/packaging/Makefile
+++ b/components/packaging/Makefile
@@ -20,7 +20,7 @@ rpm: ## build rpm packages
 		$(MAKE) -C $@ VERSION=$(VERSION) ENGINE_DIR=$(ENGINE_DIR) CLI_DIR=$(CLI_DIR) $${p}; \
 	done
 
-deb: DOCKER_BUILD_PKGS:=ubuntu-zesty ubuntu-yakkety ubuntu-xenial ubuntu-trusty debian-stretch debian-wheezy debian-jessie
+deb: DOCKER_BUILD_PKGS:=ubuntu-zesty ubuntu-yakkety ubuntu-xenial ubuntu-trusty debian-stretch debian-wheezy debian-jessie raspbian-stretch raspbian-jessie
 deb: ## build deb packages
 	for p in $(DOCKER_BUILD_PKGS); do \
 		$(MAKE) -C $@ VERSION=$(VERSION) ENGINE_DIR=$(ENGINE_DIR) CLI_DIR=$(CLI_DIR) $${p}; \

--- a/components/packaging/deb/Makefile
+++ b/components/packaging/deb/Makefile
@@ -8,7 +8,7 @@ VERSION?=$(shell cat $(ENGINE_DIR)/VERSION)
 DOCKER_EXPERIMENTAL:=0
 CHOWN:=docker run --rm -v $(CURDIR):/v -w /v $(ALPINE) chown
 
-.PHONY: help clean deb ubuntu debian ubuntu-xenial ubuntu-trusty ubuntu-yakkety ubuntu-zesty debian-jessie debian-stretch debian-wheezy
+.PHONY: help clean deb ubuntu debian ubuntu-xenial ubuntu-trusty ubuntu-yakkety ubuntu-zesty debian-jessie debian-stretch debian-wheezy raspbian-jessie raspbian-stretch
 
 help: ## show make targets
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf " \033[36m%-20s\033[0m  %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -17,11 +17,13 @@ clean: ## remove build artifacts
 	[ ! -d debbuild ] || $(CHOWN) -R $(shell id -u):$(shell id -g) debbuild
 	$(RM) -r debbuild
 
-deb: ubuntu debian ## build all deb packages
+deb: ubuntu debian raspbian ## build all deb packages
 
 ubuntu: ubuntu-zesty ubuntu-yakkety ubuntu-xenial ubuntu-trusty ## build all ubuntu deb packages
 
 debian: debian-stretch debian-wheezy debian-jessie ## build all debian deb packages
+
+raspbian: raspbian-stretch raspbian-jessie ## build all raspbian deb packages
 
 ubuntu-xenial: ## build ubuntu xenial deb packages
 	docker build -t debbuild-$@/$(ARCH) -f $(CURDIR)/$@/Dockerfile.$(ARCH) .
@@ -90,6 +92,28 @@ debian-stretch: ## build debian stretch deb packages
 	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
 
 debian-wheezy: ## build debian wheezy deb packages
+	docker build -t debbuild-$@/$(ARCH) -f $(CURDIR)/$@/Dockerfile.$(ARCH) .
+	docker run --rm \
+		-e VERSION=$(VERSION) \
+		-e DOCKER_GITCOMMIT=$(GITCOMMIT) \
+		-v $(CURDIR)/debbuild/$@:/build \
+		-v $(ENGINE_DIR):/engine \
+		-v $(CLI_DIR):/cli \
+		debbuild-$@/$(ARCH)
+	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
+
+raspbian-jessie: ## build raspbian jessie deb packages
+	docker build -t debbuild-$@/$(ARCH) -f $(CURDIR)/$@/Dockerfile.$(ARCH) .
+	docker run --rm \
+		-e VERSION=$(VERSION) \
+		-e DOCKER_GITCOMMIT=$(GITCOMMIT) \
+		-v $(CURDIR)/debbuild/$@:/build \
+		-v $(ENGINE_DIR):/engine \
+		-v $(CLI_DIR):/cli \
+		debbuild-$@/$(ARCH)
+	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
+
+raspbian-stretch: ## build raspbian stretch deb packages
 	docker build -t debbuild-$@/$(ARCH) -f $(CURDIR)/$@/Dockerfile.$(ARCH) .
 	docker run --rm \
 		-e VERSION=$(VERSION) \

--- a/components/packaging/deb/raspbian-jessie/Dockerfile.armv7l
+++ b/components/packaging/deb/raspbian-jessie/Dockerfile.armv7l
@@ -1,0 +1,35 @@
+FROM resin/rpi-raspbian:jessie
+
+# allow replacing archive mirror
+ARG APT_MIRROR=archive.raspbian.org
+RUN sed -ri "s/archive.raspbian.org/$APT_MIRROR/g" /etc/apt/sources.list
+
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev  pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+ENV GO_VERSION 1.8.3
+ENV GOARM 6
+RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
+ENV PATH $PATH:/usr/local/go/bin
+
+ENV GOPATH /go
+
+ENV DOCKER_BUILDTAGS apparmor pkcs11 selinux
+ENV RUNC_BUILDTAGS apparmor selinux
+
+COPY common/ /root/build-deb/debian
+COPY build-deb /root/build-deb/build-deb
+
+RUN mkdir -p /go/src/github.com/docker && \
+	mkdir -p /go/src/github.com/opencontainers && \
+	ln -snf /engine /root/build-deb/engine && \
+	ln -snf /cli /root/build-deb/cli && \
+	ln -snf /root/build-deb/engine /go/src/github.com/docker/docker && \
+	ln -snf /root/build-deb/cli /go/src/github.com/docker/cli
+
+
+ENV DISTRO raspbian
+ENV SUITE jessie
+
+WORKDIR /root/build-deb
+
+ENTRYPOINT ["/root/build-deb/build-deb"]

--- a/components/packaging/deb/raspbian-stretch/Dockerfile.armv7l
+++ b/components/packaging/deb/raspbian-stretch/Dockerfile.armv7l
@@ -1,0 +1,35 @@
+FROM resin/rpi-raspbian:stretch
+
+# allow replacing archive mirror
+ARG APT_MIRROR=archive.raspbian.org
+RUN sed -ri "s/archive.raspbian.org/$APT_MIRROR/g" /etc/apt/sources.list
+
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+ENV GO_VERSION 1.8.3
+ENV GOARM 6
+RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
+ENV PATH $PATH:/usr/local/go/bin
+
+ENV GOPATH /go
+
+ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
+ENV RUNC_BUILDTAGS apparmor seccomp selinux
+
+COPY common/ /root/build-deb/debian
+COPY build-deb /root/build-deb/build-deb
+
+RUN mkdir -p /go/src/github.com/docker && \
+	mkdir -p /go/src/github.com/opencontainers && \
+	ln -snf /engine /root/build-deb/engine && \
+	ln -snf /cli /root/build-deb/cli && \
+	ln -snf /root/build-deb/engine /go/src/github.com/docker/docker && \
+	ln -snf /root/build-deb/cli /go/src/github.com/docker/cli
+
+
+ENV DISTRO raspbian
+ENV SUITE stretch
+
+WORKDIR /root/build-deb
+
+ENTRYPOINT ["/root/build-deb/build-deb"]


### PR DESCRIPTION
> Please do not send pull requests to this docker/docker-ce repository.
> 
> We do, however, take contributions gladly.
> 
> See https://github.com/docker/docker-ce/blob/master/CONTRIBUTING.md
> 
> Thanks!

Well I think I have to ignore this advice above as I want to add a PR for the `packaging` folder.

This PR adds build steps to create DEB packages for Raspbian and for all Raspberry Pi models including the ARMv6 Pi Zero, Pi Zero W or old Raspberry Pi (1) model A/B.

I'm now running 17.07.0-dev on my Raspberry Pi Zero W.

I kept the names of the Dockerfiles at `Dockerfile.armv7l` so someone can build them on eg. Scaleway servers.

The only difference to the debian-jessie/Dockerfile.armv7l is using a different base image with Raspbian installed as well as setting `ENV GOARM 6` to create Pi Zero compatible binaries.

Picture of a small wireless Docker host:

<img width="1034" alt="docker-ce-on-pi-zero-w" src="https://cloud.githubusercontent.com/assets/207759/26790034/91fb5028-4a12-11e7-9104-1185a1b227a9.png">

It would be great if https://download.docker.com/linux/raspbian/ could be populated with these raspbian deb packages to have Docker CE 17.06 available for Raspberry Pi projects.
