### PR TITLE
Add link to docker-ce-packaging repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,3 +4,4 @@ Want to contribute on Docker CE? Awesome!
 
 * Changes to the `engine` should be directed upstream to https://github.com/moby/moby
 * Changes to the `cli` should be directed upstream to https://github.com/docker/cli
+* Changes to the `packaging` should be directed upstream to https://github.com/docker/docker-ce-packaging


### PR DESCRIPTION
Add a link to the docker/docker-ce-packaging repo so others could contribute at the right place.