### PR TITLE
[cherry-pick] vendor: Ensure service images get default tag and print familiar strings

### DIFF
--- a/components/cli/vendor.conf
+++ b/components/cli/vendor.conf
@@ -7,7 +7,7 @@ github.com/coreos/etcd 824277cb3a577a0e8c829ca9ec557b973fe06d20
 github.com/cpuguy83/go-md2man a65d4d2de4d5f7c74868dfa9b202a3c8be315aaa
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
 github.com/docker/distribution b38e5838b7b2f2ad48e06ec4b500011976080621
-github.com/docker/docker 45c6f4262a865a03adaac291a9ce33c0f2190d77 
+# github.com/docker/docker 45c6f4262a865a03adaac291a9ce33c0f2190d77
 github.com/docker/docker-credential-helpers v0.5.0
 github.com/docker/go d30aec9fd63c35133f8f79c3412ad91a3b08be06
 github.com/docker/go-connections e15c02316c12de00874640cd76311849de2aeed5
@@ -16,7 +16,7 @@ github.com/docker/go-units 9e638d38cf6977a37a8ea0078f3ee75a7cdb2dd1
 github.com/docker/libnetwork b13e0604016a4944025aaff521d9c125850b0d04
 github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a
 github.com/docker/notary v0.4.2
-github.com/docker/swarmkit 1a3e510517be82d18ac04380b5f71eddf06c2fc0 
+github.com/docker/swarmkit 1a3e510517be82d18ac04380b5f71eddf06c2fc0
 github.com/flynn-archive/go-shlex 3f9db97f856818214da2e1057f8ad84803971cff
 github.com/gogo/protobuf 7efa791bd276fd4db00867cbd982b552627c24cb
 github.com/golang/protobuf 8ee79997227bf9b34611aee7946ae64735e6fd93

--- a/components/cli/vendor/github.com/docker/docker/client/service_create.go
+++ b/components/cli/vendor/github.com/docker/docker/client/service_create.go
@@ -24,14 +24,18 @@ func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec,
 		headers["X-Registry-Auth"] = []string{options.EncodedRegistryAuth}
 	}
 
+	// ensure that the image is tagged
+	if taggedImg := imageWithTagString(service.TaskTemplate.ContainerSpec.Image); taggedImg != "" {
+		service.TaskTemplate.ContainerSpec.Image = taggedImg
+	}
+
 	// Contact the registry to retrieve digest and platform information
 	if options.QueryRegistry {
 		distributionInspect, err := cli.DistributionInspect(ctx, service.TaskTemplate.ContainerSpec.Image, options.EncodedRegistryAuth)
 		distErr = err
 		if err == nil {
 			// now pin by digest if the image doesn't already contain a digest
-			img := imageWithDigestString(service.TaskTemplate.ContainerSpec.Image, distributionInspect.Descriptor.Digest)
-			if img != "" {
+			if img := imageWithDigestString(service.TaskTemplate.ContainerSpec.Image, distributionInspect.Descriptor.Digest); img != "" {
 				service.TaskTemplate.ContainerSpec.Image = img
 			}
 			// add platforms that are compatible with the service
@@ -55,21 +59,29 @@ func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec,
 }
 
 // imageWithDigestString takes an image string and a digest, and updates
-// the image string if it didn't originally contain a digest. It assumes
-// that the image string is not an image ID
+// the image string if it didn't originally contain a digest. It returns
+// an empty string if there are no updates.
 func imageWithDigestString(image string, dgst digest.Digest) string {
-	isCanonical := false
-	ref, err := reference.ParseAnyReference(image)
+	namedRef, err := reference.ParseNormalizedNamed(image)
 	if err == nil {
-		_, isCanonical = ref.(reference.Canonical)
-
-		if !isCanonical {
-			namedRef, _ := ref.(reference.Named)
+		if _, isCanonical := namedRef.(reference.Canonical); !isCanonical {
+			// ensure that image gets a default tag if none is provided
 			img, err := reference.WithDigest(namedRef, dgst)
 			if err == nil {
-				return img.String()
+				return reference.FamiliarString(img)
 			}
 		}
+	}
+	return ""
+}
+
+// imageWithTagString takes an image string, and returns a tagged image
+// string, adding a 'latest' tag if one was not provided. It returns an
+// emptry string if a canonical reference was provided
+func imageWithTagString(image string) string {
+	namedRef, err := reference.ParseNormalizedNamed(image)
+	if err == nil {
+		return reference.FamiliarString(reference.TagNameOnly(namedRef))
 	}
 	return ""
 }

--- a/components/cli/vendor/github.com/docker/docker/client/service_update.go
+++ b/components/cli/vendor/github.com/docker/docker/client/service_update.go
@@ -35,6 +35,11 @@ func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version 
 
 	query.Set("version", strconv.FormatUint(version.Index, 10))
 
+	// ensure that the image is tagged
+	if taggedImg := imageWithTagString(service.TaskTemplate.ContainerSpec.Image); taggedImg != "" {
+		service.TaskTemplate.ContainerSpec.Image = taggedImg
+	}
+
 	// Contact the registry to retrieve digest and platform information
 	// This happens only when the image has changed
 	if options.QueryRegistry {
@@ -42,8 +47,7 @@ func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version 
 		distErr = err
 		if err == nil {
 			// now pin by digest if the image doesn't already contain a digest
-			img := imageWithDigestString(service.TaskTemplate.ContainerSpec.Image, distributionInspect.Descriptor.Digest)
-			if img != "" {
+			if img := imageWithDigestString(service.TaskTemplate.ContainerSpec.Image, distributionInspect.Descriptor.Digest); img != "" {
 				service.TaskTemplate.ContainerSpec.Image = img
 			}
 			// add platforms that are compatible with the service


### PR DESCRIPTION
Cherry picking https://github.com/moby/moby/pull/33279 into `components/cli/vendor/github.com/docker/docker`.

This is related to the changes in https://github.com/docker/docker-ce/pull/13

cc @andrewhsu @mlaventure @thaJeztah 