### PR TITLE
[cherry-pick] Enable client side digest pinning for stack deploy

### DIFF
--- a/components/cli/cli/command/stack/deploy_bundlefile.go
+++ b/components/cli/cli/command/stack/deploy_bundlefile.go
@@ -87,5 +87,5 @@ func deployBundle(ctx context.Context, dockerCli command.Cli, opts deployOptions
 	if err := createNetworks(ctx, dockerCli, namespace, networks); err != nil {
 		return err
 	}
-	return deployServices(ctx, dockerCli, services, namespace, opts.sendRegistryAuth)
+	return deployServices(ctx, dockerCli, services, namespace, opts.sendRegistryAuth, opts.noResolveImage)
 }

--- a/components/cli/cli/command/stack/deploy_bundlefile.go
+++ b/components/cli/cli/command/stack/deploy_bundlefile.go
@@ -87,5 +87,5 @@ func deployBundle(ctx context.Context, dockerCli command.Cli, opts deployOptions
 	if err := createNetworks(ctx, dockerCli, namespace, networks); err != nil {
 		return err
 	}
-	return deployServices(ctx, dockerCli, services, namespace, opts.sendRegistryAuth, opts.noResolveImage)
+	return deployServices(ctx, dockerCli, services, namespace, opts.sendRegistryAuth, opts.resolveImage)
 }

--- a/components/cli/cli/command/stack/deploy_composefile.go
+++ b/components/cli/cli/command/stack/deploy_composefile.go
@@ -92,7 +92,7 @@ func deployCompose(ctx context.Context, dockerCli command.Cli, opts deployOption
 	if err != nil {
 		return err
 	}
-	return deployServices(ctx, dockerCli, services, namespace, opts.sendRegistryAuth, opts.noResolveImage)
+	return deployServices(ctx, dockerCli, services, namespace, opts.sendRegistryAuth, opts.resolveImage)
 }
 
 func getServicesDeclaredNetworks(serviceConfigs []composetypes.ServiceConfig) map[string]struct{} {
@@ -282,7 +282,7 @@ func deployServices(
 	services map[string]swarm.ServiceSpec,
 	namespace convert.Namespace,
 	sendAuth bool,
-	noResolveImage bool,
+	resolveImage string,
 ) error {
 	apiClient := dockerCli.Client()
 	out := dockerCli.Out()
@@ -315,10 +315,8 @@ func deployServices(
 
 			updateOpts := types.ServiceUpdateOptions{EncodedRegistryAuth: encodedAuth}
 
-			if image != service.Spec.Labels["com.docker.stack.image"] {
-				if !noResolveImage {
-					updateOpts.QueryRegistry = true
-				}
+			if resolveImage == resolveImageAlways || (resolveImage == resolveImageChanged && image != service.Spec.Labels[convert.LabelImage]) {
+				updateOpts.QueryRegistry = true
 			}
 
 			response, err := apiClient.ServiceUpdate(
@@ -341,7 +339,7 @@ func deployServices(
 			createOpts := types.ServiceCreateOptions{EncodedRegistryAuth: encodedAuth}
 
 			// query registry if flag disabling it was not set
-			if !noResolveImage {
+			if resolveImage == resolveImageAlways || resolveImage == resolveImageChanged {
 				createOpts.QueryRegistry = true
 			}
 

--- a/components/cli/cli/command/stack/deploy_composefile.go
+++ b/components/cli/cli/command/stack/deploy_composefile.go
@@ -92,7 +92,7 @@ func deployCompose(ctx context.Context, dockerCli command.Cli, opts deployOption
 	if err != nil {
 		return err
 	}
-	return deployServices(ctx, dockerCli, services, namespace, opts.sendRegistryAuth)
+	return deployServices(ctx, dockerCli, services, namespace, opts.sendRegistryAuth, opts.noResolveImage)
 }
 
 func getServicesDeclaredNetworks(serviceConfigs []composetypes.ServiceConfig) map[string]struct{} {
@@ -282,6 +282,7 @@ func deployServices(
 	services map[string]swarm.ServiceSpec,
 	namespace convert.Namespace,
 	sendAuth bool,
+	noResolveImage bool,
 ) error {
 	apiClient := dockerCli.Client()
 	out := dockerCli.Out()
@@ -300,9 +301,9 @@ func deployServices(
 		name := namespace.Scope(internalName)
 
 		encodedAuth := ""
+		image := serviceSpec.TaskTemplate.ContainerSpec.Image
 		if sendAuth {
 			// Retrieve encoded auth token from the image reference
-			image := serviceSpec.TaskTemplate.ContainerSpec.Image
 			encodedAuth, err = command.RetrieveAuthTokenFromImage(ctx, dockerCli, image)
 			if err != nil {
 				return err
@@ -312,10 +313,14 @@ func deployServices(
 		if service, exists := existingServiceMap[name]; exists {
 			fmt.Fprintf(out, "Updating service %s (id: %s)\n", name, service.ID)
 
-			updateOpts := types.ServiceUpdateOptions{}
-			if sendAuth {
-				updateOpts.EncodedRegistryAuth = encodedAuth
+			updateOpts := types.ServiceUpdateOptions{EncodedRegistryAuth: encodedAuth}
+
+			if image != service.Spec.Labels["com.docker.stack.image"] {
+				if !noResolveImage {
+					updateOpts.QueryRegistry = true
+				}
 			}
+
 			response, err := apiClient.ServiceUpdate(
 				ctx,
 				service.ID,
@@ -333,10 +338,13 @@ func deployServices(
 		} else {
 			fmt.Fprintf(out, "Creating service %s\n", name)
 
-			createOpts := types.ServiceCreateOptions{}
-			if sendAuth {
-				createOpts.EncodedRegistryAuth = encodedAuth
+			createOpts := types.ServiceCreateOptions{EncodedRegistryAuth: encodedAuth}
+
+			// query registry if flag disabling it was not set
+			if !noResolveImage {
+				createOpts.QueryRegistry = true
 			}
+
 			if _, err := apiClient.ServiceCreate(ctx, serviceSpec, createOpts); err != nil {
 				return err
 			}

--- a/components/cli/cli/compose/convert/service.go
+++ b/components/cli/cli/compose/convert/service.go
@@ -46,6 +46,12 @@ func Services(
 		if err != nil {
 			return nil, errors.Wrapf(err, "service %s", service.Name)
 		}
+		// add an image label to serviceSpec
+		if serviceSpec.Labels == nil {
+			serviceSpec.Labels = make(map[string]string)
+		}
+		serviceSpec.Labels["com.docker.stack.image"] = service.Image
+
 		result[service.Name] = serviceSpec
 	}
 

--- a/components/cli/cli/compose/convert/service.go
+++ b/components/cli/cli/compose/convert/service.go
@@ -18,7 +18,11 @@ import (
 	"github.com/pkg/errors"
 )
 
-const defaultNetwork = "default"
+const (
+	defaultNetwork = "default"
+	// LabelImage is the label used to store image name provided in the compose file
+	LabelImage = "com.docker.stack.image"
+)
 
 // Services from compose-file types to engine API types
 func Services(
@@ -46,12 +50,6 @@ func Services(
 		if err != nil {
 			return nil, errors.Wrapf(err, "service %s", service.Name)
 		}
-		// add an image label to serviceSpec
-		if serviceSpec.Labels == nil {
-			serviceSpec.Labels = make(map[string]string)
-		}
-		serviceSpec.Labels["com.docker.stack.image"] = service.Image
-
 		result[service.Name] = serviceSpec
 	}
 
@@ -163,6 +161,9 @@ func convertService(
 		Mode:         mode,
 		UpdateConfig: convertUpdateConfig(service.Deploy.UpdateConfig),
 	}
+
+	// add an image label to serviceSpec
+	serviceSpec.Labels[LabelImage] = service.Image
 
 	// ServiceSpec.Networks is deprecated and should not have been used by
 	// this package. It is possible to update TaskTemplate.Networks, but it

--- a/components/engine/hack/integration-cli-on-swarm/host/dockercmd.go
+++ b/components/engine/hack/integration-cli-on-swarm/host/dockercmd.go
@@ -37,6 +37,7 @@ func deployStack(unusedCli *client.Client, stackName, composeFilePath string) er
 		{"docker", "stack", "deploy",
 			"--compose-file", composeFilePath,
 			"--with-registry-auth",
+			"--resolve-image", "never",
 			stackName},
 	})
 }

--- a/components/engine/integration-cli/docker_cli_stack_test.go
+++ b/components/engine/integration-cli/docker_cli_stack_test.go
@@ -62,6 +62,7 @@ func (s *DockerSwarmSuite) TestStackDeployComposeFile(c *check.C) {
 	testStackName := "testdeploy"
 	stackArgs := []string{
 		"stack", "deploy",
+		"--resolve-image", "never",
 		"--compose-file", "fixtures/deploy/default.yaml",
 		testStackName,
 	}
@@ -88,6 +89,7 @@ func (s *DockerSwarmSuite) TestStackDeployWithSecretsTwice(c *check.C) {
 	testStackName := "testdeploy"
 	stackArgs := []string{
 		"stack", "deploy",
+		"--resolve-image", "never",
 		"--compose-file", "fixtures/deploy/secrets.yaml",
 		testStackName,
 	}
@@ -120,6 +122,7 @@ func (s *DockerSwarmSuite) TestStackRemove(c *check.C) {
 	stackName := "testdeploy"
 	stackArgs := []string{
 		"stack", "deploy",
+		"--resolve-image", "never",
 		"--compose-file", "fixtures/deploy/remove.yaml",
 		stackName,
 	}
@@ -179,6 +182,7 @@ func (s *DockerSwarmSuite) TestStackDeployWithDAB(c *check.C) {
 	// deploy
 	stackArgs := []string{
 		"stack", "deploy",
+		"--resolve-image", "never",
 		"--bundle-file", testDABFileName,
 		testStackName,
 	}


### PR DESCRIPTION
This PR cherry-picks the two commits from https://github.com/docker/cli/pull/121. It is required to avoid a digest-pinning regression for `docker stack deploy`.

It enables digest pinning for `docker stack deploy`, and adds a `--resolve-image` flag to `stack deploy` to provide options to control it.

Some of the refactoring from https://github.com/docker/cli/pull/145 that came earlier doesn't show up in this cherry-pick, but I've tried to make sure the changes here don't cause problems, since https://github.com/docker/cli/pull/121 is based on top of https://github.com/docker/cli/pull/145 (cc @dnephin)

Tests might fail right now, I'll add a commit to fix them. In particular, changes from https://github.com/moby/moby/pull/33386 are what will be needed.

cc @andrewhsu 
