### PR TITLE
Handle case of configs on old daemon

### DIFF
--- a/components/cli/cli/command/service/parse.go
+++ b/components/cli/cli/command/service/parse.go
@@ -12,6 +12,10 @@ import (
 // ParseSecrets retrieves the secrets with the requested names and fills
 // secret IDs into the secret references.
 func ParseSecrets(client client.SecretAPIClient, requestedSecrets []*swarmtypes.SecretReference) ([]*swarmtypes.SecretReference, error) {
+	if len(requestedSecrets) == 0 {
+		return []*swarmtypes.SecretReference{}, nil
+	}
+
 	secretRefs := make(map[string]*swarmtypes.SecretReference)
 	ctx := context.Background()
 
@@ -61,6 +65,10 @@ func ParseSecrets(client client.SecretAPIClient, requestedSecrets []*swarmtypes.
 // ParseConfigs retrieves the configs from the requested names and converts
 // them to config references to use with the spec
 func ParseConfigs(client client.ConfigAPIClient, requestedConfigs []*swarmtypes.ConfigReference) ([]*swarmtypes.ConfigReference, error) {
+	if len(requestedConfigs) == 0 {
+		return []*swarmtypes.ConfigReference{}, nil
+	}
+
 	configRefs := make(map[string]*swarmtypes.ConfigReference)
 	ctx := context.Background()
 


### PR DESCRIPTION
Cherry-picked from docker/cli#162

If configs are declared for a service and pointing on an old
daemon, error out properly (instead of "page not found").

If there is no configs declared, don't call convertServiceConfigObjs
to avoid having an error.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
(cherry picked from commit cf5550c4260bcea0f733c7abfc6bdf0188357eea)
Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>
