### PR TITLE
revert Set OPOST on bsd

### DIFF
--- a/components/cli/vendor.conf
+++ b/components/cli/vendor.conf
@@ -7,8 +7,7 @@ github.com/coreos/etcd 824277cb3a577a0e8c829ca9ec557b973fe06d20
 github.com/cpuguy83/go-md2man a65d4d2de4d5f7c74868dfa9b202a3c8be315aaa
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
 github.com/docker/distribution b38e5838b7b2f2ad48e06ec4b500011976080621
-# commented out, since we needed to advance just github.com/docker/docker/pkg/term/termios_bsd.go
-# github.com/docker/docker 45c6f4262a865a03adaac291a9ce33c0f2190d77
+github.com/docker/docker 45c6f4262a865a03adaac291a9ce33c0f2190d77 
 github.com/docker/docker-credential-helpers v0.5.0
 github.com/docker/go d30aec9fd63c35133f8f79c3412ad91a3b08be06
 github.com/docker/go-connections e15c02316c12de00874640cd76311849de2aeed5
@@ -17,7 +16,7 @@ github.com/docker/go-units 9e638d38cf6977a37a8ea0078f3ee75a7cdb2dd1
 github.com/docker/libnetwork b13e0604016a4944025aaff521d9c125850b0d04
 github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a
 github.com/docker/notary v0.4.2
-github.com/docker/swarmkit 1a3e510517be82d18ac04380b5f71eddf06c2fc0
+github.com/docker/swarmkit 1a3e510517be82d18ac04380b5f71eddf06c2fc0 
 github.com/flynn-archive/go-shlex 3f9db97f856818214da2e1057f8ad84803971cff
 github.com/gogo/protobuf 7efa791bd276fd4db00867cbd982b552627c24cb
 github.com/golang/protobuf 8ee79997227bf9b34611aee7946ae64735e6fd93

--- a/components/cli/vendor/github.com/docker/docker/pkg/term/termios_bsd.go
+++ b/components/cli/vendor/github.com/docker/docker/pkg/term/termios_bsd.go
@@ -27,7 +27,7 @@ func MakeRaw(fd uintptr) (*State, error) {
 
 	newState := oldState.termios
 	newState.Iflag &^= (unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP | unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON)
-	newState.Oflag |= unix.OPOST
+	newState.Oflag &^= unix.OPOST
 	newState.Lflag &^= (unix.ECHO | unix.ECHONL | unix.ICANON | unix.ISIG | unix.IEXTEN)
 	newState.Cflag &^= (unix.CSIZE | unix.PARENB)
 	newState.Cflag |= unix.CS8

--- a/components/engine/pkg/term/termios_bsd.go
+++ b/components/engine/pkg/term/termios_bsd.go
@@ -27,7 +27,7 @@ func MakeRaw(fd uintptr) (*State, error) {
 
 	newState := oldState.termios
 	newState.Iflag &^= (unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP | unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON)
-	newState.Oflag |= unix.OPOST
+	newState.Oflag &^= unix.OPOST
 	newState.Lflag &^= (unix.ECHO | unix.ECHONL | unix.ICANON | unix.ISIG | unix.IEXTEN)
 	newState.Cflag &^= (unix.CSIZE | unix.PARENB)
 	newState.Cflag |= unix.CS8


### PR DESCRIPTION
To address https://github.com/moby/moby/issues/33101 will revert the changes originally put in with https://github.com/docker/docker-ce/pull/25

Similar revert was performed upstream in https://github.com/docker/cli/pull/166 and https://github.com/moby/moby/pull/33577