### PR TITLE
Do not reuse a http.Request after a failure in callWithRetry

### DIFF
--- a/components/engine/pkg/plugins/client.go
+++ b/components/engine/pkg/plugins/client.go
@@ -129,15 +129,15 @@ func (c *Client) SendFile(serviceMethod string, data io.Reader, ret interface{})
 }
 
 func (c *Client) callWithRetry(serviceMethod string, data io.Reader, retry bool) (io.ReadCloser, error) {
-	req, err := c.requestFactory.NewRequest(serviceMethod, data)
-	if err != nil {
-		return nil, err
-	}
-
 	var retries int
 	start := time.Now()
 
 	for {
+		req, err := c.requestFactory.NewRequest(serviceMethod, data)
+		if err != nil {
+			return nil, err
+		}
+
 		resp, err := c.http.Do(req)
 		if err != nil {
 			if !retry {


### PR DESCRIPTION
Cherry-picked from: moby/moby#33413

Closes: #33412

Signed-off-by: Felix Abecassis <fabecassis@nvidia.com>
(cherry picked from commit 62871ef2fa52b0a2e426c30f36d35a9ba1e92fac)
Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>
