### PR TITLE
Allow --detach and --quiet flags when using --rollback

### DIFF
--- a/components/cli/cli/command/service/update.go
+++ b/components/cli/cli/command/service/update.go
@@ -131,7 +131,7 @@ func runUpdate(dockerCli *command.DockerCli, flags *pflag.FlagSet, options *serv
 		// Rollback can't be combined with other flags.
 		otherFlagsPassed := false
 		flags.VisitAll(func(f *pflag.Flag) {
-			if f.Name == "rollback" {
+			if f.Name == "rollback" || f.Name == "detach" || f.Name == "quiet" {
 				return
 			}
 			if flags.Changed(f.Name) {


### PR DESCRIPTION
Cherry-picked from: docker/cli#144

Commit 78c204ef798c7380e11ba26e5cd231e04fc6efe4 added
(f9bd8ec8b268581f93095c5a80679f0a8ff498bf in the moby repo)
a validation to prevent `--rollback` from being used
in combination with other flags that update the
service spec.

This validation was not taking into account that
some flags only affect the CLI behavior, and
are okay to be used when rolling back.

This patch updates the validation, and adds
`--quiet` and `--detach` to the list of allowed
flags.

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
(cherry picked from commit f10f29df8d7ffede3faa29120a06c199e52a1d0c)
Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>
