### PR TITLE
Remove deprecated -e/--email flag from docker login

### DIFF
--- a/components/cli/cli/command/registry/login.go
+++ b/components/cli/cli/command/registry/login.go
@@ -41,10 +41,6 @@ func NewLoginCommand(dockerCli command.Cli) *cobra.Command {
 	flags.StringVarP(&opts.user, "username", "u", "", "Username")
 	flags.StringVarP(&opts.password, "password", "p", "", "Password")
 
-	// Deprecated in 1.11: Should be removed in docker 17.06
-	flags.StringVarP(&opts.email, "email", "e", "", "Email")
-	flags.MarkDeprecated("email", "will be removed in 17.06.")
-
 	return cmd
 }
 


### PR DESCRIPTION
Cherry-picked from: docker/cli#143

The `docker login -e` / `docker login --email` option was deprecated in
Docker 1.11 (https://github.com/moby/moby/releases/tag/v1.11.0) through
aee260d4eb3aa0fc86ee5038010b7bbc24512ae5 (April 2016), and when used has
been outputing a deprecation warning since;

    Flag --email has been deprecated, will be removed in 17.06.

Originally this option was scheduled to be removed in docker 1.13, but
extended to docker 17.06 due to a change in our deprecation policy.

Given that only docker 1.10 and older use this flag (which is EOL, including
for CS versions, as of February 2017), will now be removed.

With this patch, `docker login` will now produce an Error if the flag
is used.

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
(cherry picked from commit 8b383d23514293bd0accc0dab9e8289142a3bb5a)
Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>
