### PR TITLE
cherry-pick: Disable legacy (v1) registries by default

### DIFF
--- a/components/engine/cmd/dockerd/daemon.go
+++ b/components/engine/cmd/dockerd/daemon.go
@@ -407,8 +407,12 @@ func loadDaemonCliConfig(opts daemonOptions) (*config.Config, error) {
 		return nil, err
 	}
 
+	if conf.V2Only == false {
+		logrus.Warnf(`The "disable-legacy-registry" option is deprecated and wil be removed in Docker v17.12. Interacting with legacy (v1) registries will no longer be supported in Docker v17.12"`)
+	}
+
 	if flags.Changed("graph") {
-		logrus.Warnf(`the "-g / --graph" flag is deprecated. Please use "--data-root" instead`)
+		logrus.Warnf(`The "-g / --graph" flag is deprecated. Please use "--data-root" instead`)
 	}
 
 	// Labels of the docker engine used to allow multiple values associated with the same key.

--- a/components/engine/cmd/dockerd/daemon_unix_test.go
+++ b/components/engine/cmd/dockerd/daemon_unix_test.go
@@ -102,7 +102,7 @@ func TestLoadDaemonConfigWithTrueDefaultValuesLeaveDefaults(t *testing.T) {
 }
 
 func TestLoadDaemonConfigWithLegacyRegistryOptions(t *testing.T) {
-	content := `{"disable-legacy-registry": true}`
+	content := `{"disable-legacy-registry": false}`
 	tempFile := tempfile.NewTempFile(t, "config", content)
 	defer tempFile.Remove()
 
@@ -110,5 +110,5 @@ func TestLoadDaemonConfigWithLegacyRegistryOptions(t *testing.T) {
 	loadedConfig, err := loadDaemonCliConfig(opts)
 	require.NoError(t, err)
 	require.NotNil(t, loadedConfig)
-	assert.True(t, loadedConfig.V2Only)
+	assert.False(t, loadedConfig.V2Only)
 }

--- a/components/engine/contrib/completion/zsh/_docker
+++ b/components/engine/contrib/completion/zsh/_docker
@@ -2620,7 +2620,7 @@ __docker_subcommand() {
                 "($help)--default-gateway-v6[Container default gateway IPv6 address]:IPv6 address: " \
                 "($help)--default-shm-size=[Default shm size for containers]:size:" \
                 "($help)*--default-ulimit=[Default ulimits for containers]:ulimit: " \
-                "($help)--disable-legacy-registry[Disable contacting legacy registries]" \
+                "($help)--disable-legacy-registry[Disable contacting legacy registries (default true)]" \
                 "($help)*--dns=[DNS server to use]:DNS: " \
                 "($help)*--dns-opt=[DNS options to use]:DNS option: " \
                 "($help)*--dns-search=[DNS search domains to use]:DNS search: " \

--- a/components/engine/docs/deprecated.md
+++ b/components/engine/docs/deprecated.md
@@ -292,7 +292,7 @@ of the `--changes` flag that allows to pass `Dockerfile` commands.
 
 **Target For Removal In Release: v17.12**
 
-Version 1.9 adds a flag (`--disable-legacy-registry=false`) which prevents the
+Version 1.8.3 added a flag (`--disable-legacy-registry=false`) which prevents the
 docker daemon from `pull`, `push`, and `login` operations against v1
 registries.  Though enabled by default, this signals the intent to deprecate
 the v1 protocol.

--- a/components/engine/docs/reference/commandline/dockerd.md
+++ b/components/engine/docs/reference/commandline/dockerd.md
@@ -42,7 +42,7 @@ Options:
       --default-gateway-v6 ip                 Container default gateway IPv6 address
       --default-runtime string                Default OCI runtime for containers (default "runc")
       --default-ulimit ulimit                 Default ulimits for containers (default [])
-      --disable-legacy-registry               Disable contacting legacy registries
+      --disable-legacy-registry               Disable contacting legacy registries (default true)
       --dns list                              DNS server to use (default [])
       --dns-opt list                          DNS options to use (default [])
       --dns-search list                       DNS search domains to use (default [])
@@ -901,7 +901,18 @@ system's list of trusted CAs instead of enabling `--insecure-registry`.
 
 ##### Legacy Registries
 
-Enabling `--disable-legacy-registry` forces a docker daemon to only interact with registries which support the V2 protocol.  Specifically, the daemon will not attempt `push`, `pull` and `login` to v1 registries.  The exception to this is `search` which can still be performed on v1 registries.
+Operations against registries supporting only the legacy v1 protocol are
+disabled by default. Specifically, the daemon will not attempt `push`,
+`pull` and `login` to v1 registries. The exception to this is `search`
+which can still be performed on v1 registries.
+
+Add `"disable-legacy-registry":false` to the [daemon configuration
+file](#daemon-configuration-file), or set the
+`--disable-legacy-registry=false` flag, if you need to interact with
+registries that have not yet migrated to the v2 protocol.
+
+Interaction v1 registries will no longer be supported in Docker v17.12,
+and the `disable-legacy-registry` configuration option will be removed.
 
 #### Running a Docker daemon behind an HTTPS_PROXY
 

--- a/components/engine/integration-cli/docker_cli_pull_test.go
+++ b/components/engine/integration-cli/docker_cli_pull_test.go
@@ -258,10 +258,13 @@ func (s *DockerHubPullSuite) TestPullClientDisconnect(c *check.C) {
 }
 
 func (s *DockerRegistryAuthHtpasswdSuite) TestPullNoCredentialsNotFound(c *check.C) {
+	// @TODO TestPullNoCredentialsNotFound expects docker to fall back to a v1 registry, so has to be updated for v17.12, when v1 registries are no longer supported
+	s.d.StartWithBusybox(c, "--disable-legacy-registry=false")
+
 	// we don't care about the actual image, we just want to see image not found
 	// because that means v2 call returned 401 and we fell back to v1 which usually
 	// gives a 404 (in this case the test registry doesn't handle v1 at all)
-	out, _, err := dockerCmdWithError("pull", privateRegistryURL+"/busybox")
+	out, err := s.d.Cmd("pull", privateRegistryURL+"/busybox")
 	c.Assert(err, check.NotNil, check.Commentf(out))
 	c.Assert(out, checker.Contains, "Error: image busybox:latest not found")
 }

--- a/components/engine/integration-cli/docker_cli_registry_user_agent_test.go
+++ b/components/engine/integration-cli/docker_cli_registry_user_agent_test.go
@@ -98,8 +98,7 @@ func (s *DockerRegistrySuite) TestUserAgentPassThrough(c *check.C) {
 		"--insecure-registry", buildReg.URL(),
 		"--insecure-registry", pullReg.URL(),
 		"--insecure-registry", pushReg.URL(),
-		"--insecure-registry", loginReg.URL(),
-		"--disable-legacy-registry=true")
+		"--insecure-registry", loginReg.URL())
 
 	dockerfileName, cleanup1, err := makefile(fmt.Sprintf("FROM %s", buildRepoName))
 	c.Assert(err, check.IsNil, check.Commentf("Unable to create test dockerfile"))

--- a/components/engine/integration-cli/docker_cli_v2_only_test.go
+++ b/components/engine/integration-cli/docker_cli_v2_only_test.go
@@ -34,7 +34,7 @@ func makefile(contents string) (string, func(), error) {
 
 }
 
-// TestV2Only ensures that a daemon in v2-only mode does not
+// TestV2Only ensures that a daemon by default does not
 // attempt to contact any v1 registry endpoints.
 func (s *DockerRegistrySuite) TestV2Only(c *check.C) {
 	reg, err := registry.NewMock(c)
@@ -51,7 +51,7 @@ func (s *DockerRegistrySuite) TestV2Only(c *check.C) {
 
 	repoName := fmt.Sprintf("%s/busybox", reg.URL())
 
-	s.d.Start(c, "--insecure-registry", reg.URL(), "--disable-legacy-registry=true")
+	s.d.Start(c, "--insecure-registry", reg.URL())
 
 	dockerfileName, cleanup, err := makefile(fmt.Sprintf("FROM %s/busybox", reg.URL()))
 	c.Assert(err, check.IsNil, check.Commentf("Unable to create test dockerfile"))
@@ -66,7 +66,7 @@ func (s *DockerRegistrySuite) TestV2Only(c *check.C) {
 	s.d.Cmd("pull", repoName)
 }
 
-// TestV1 starts a daemon in 'normal' mode
+// TestV1 starts a daemon with legacy registries enabled
 // and ensure v1 endpoints are hit for the following operations:
 // login, push, pull, build & run
 func (s *DockerRegistrySuite) TestV1(c *check.C) {

--- a/components/engine/man/dockerd.8.md
+++ b/components/engine/man/dockerd.8.md
@@ -192,7 +192,7 @@ $ sudo dockerd --add-runtime runc=runc --add-runtime custom=/usr/local/bin/my-ru
   Default ulimits for containers.
 
 **--disable-legacy-registry**=*true*|*false*
-  Disable contacting legacy registries
+  Disable contacting legacy registries. Default is `true`.
 
 **--dns**=""
   Force Docker to use specific DNS servers

--- a/components/engine/registry/config_unix.go
+++ b/components/engine/registry/config_unix.go
@@ -21,5 +21,5 @@ func cleanPath(s string) string {
 
 // installCliPlatformFlags handles any platform specific flags for the service.
 func (options *ServiceOptions) installCliPlatformFlags(flags *pflag.FlagSet) {
-	flags.BoolVar(&options.V2Only, "disable-legacy-registry", false, "Disable contacting legacy registries")
+	flags.BoolVar(&options.V2Only, "disable-legacy-registry", true, "Disable contacting legacy registries")
 }


### PR DESCRIPTION
Cherry-picking change: https://github.com/moby/moby/pull/33629

Deprecation of interacting with v1 registries was started in docker 1.8.3, which added a --disable-legacy-registry flag.

This option was announced to be the default starting with docker 17.06, and v1 registries completely removed in docker 17.12.

This patch updates the default, and disables interaction with v1 registres by default.