### PR TITLE
Do not call the config endpoint if API is lower than 1.30

### DIFF
--- a/components/cli/cli/command/stack/client_test.go
+++ b/components/cli/cli/command/stack/client_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/docker/cli/cli/compose/convert"
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
@@ -32,6 +33,13 @@ type fakeClient struct {
 	networkRemoveFunc func(networkID string) error
 	secretRemoveFunc  func(secretID string) error
 	configRemoveFunc  func(configID string) error
+}
+
+func (cli *fakeClient) ServerVersion(ctx context.Context) (types.Version, error) {
+	return types.Version{
+		Version:    "docker-dev",
+		APIVersion: api.DefaultVersion,
+	}, nil
 }
 
 func (cli *fakeClient) ServiceList(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error) {


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vincent@sbr.pm>
(cherry picked from commit 2128b3f11208197c8d0340ac22cd4ff9d36b96cc)
Signed-off-by: Tibor Vass <tibor@docker.com>

From docker/cli#182