### PR TITLE
[17.06] Prevent a goroutine leak when healthcheck gets stopped

### DIFF
--- a/components/engine/daemon/health.go
+++ b/components/engine/daemon/health.go
@@ -186,7 +186,7 @@ func monitor(d *Daemon, c *container.Container, stop chan struct{}, probe probe)
 			logrus.Debugf("Running health check for container %s ...", c.ID)
 			startTime := time.Now()
 			ctx, cancelProbe := context.WithTimeout(context.Background(), probeTimeout)
-			results := make(chan *types.HealthcheckResult)
+			results := make(chan *types.HealthcheckResult, 1)
 			go func() {
 				healthChecksCounter.Inc()
 				result, err := probe.run(ctx, d, c)
@@ -209,8 +209,10 @@ func monitor(d *Daemon, c *container.Container, stop chan struct{}, probe probe)
 			select {
 			case <-stop:
 				logrus.Debugf("Stop healthcheck monitoring for container %s (received while probing)", c.ID)
-				// Stop timeout and kill probe, but don't wait for probe to exit.
 				cancelProbe()
+				// Wait for probe to exit (it might take a while to respond to the TERM
+				// signal and we don't want dying probes to pile up).
+				<-results
 				return
 			case result := <-results:
 				handleProbeResult(d, c, result, stop)


### PR DESCRIPTION
Backport fix:
* moby/moby#33781 Prevent a goroutine leak when healthcheck gets stopped

With cherry-pick moby/moby@67297ba:
```
$ git cherry-pick -s -x -Xsubtree=components/engine 67297ba
```

No conflicts.