### PR TITLE
[17.06] Do not error on relabel when relabel not supported

### DIFF
--- a/components/cli/vendor/github.com/docker/docker/volume/volume.go
+++ b/components/cli/vendor/github.com/docker/docker/volume/volume.go
@@ -151,6 +151,10 @@ func (m *MountPoint) Setup(mountLabel string, rootUID, rootGID int) (path string
 		if err == nil {
 			if label.RelabelNeeded(m.Mode) {
 				if err = label.Relabel(m.Source, mountLabel, label.IsShared(m.Mode)); err != nil {
+					if err == syscall.ENOTSUP {
+						err = nil
+						return
+					}
 					path = ""
 					err = errors.Wrapf(err, "error setting label on mount source '%s'", m.Source)
 					return

--- a/components/engine/volume/volume.go
+++ b/components/engine/volume/volume.go
@@ -153,6 +153,10 @@ func (m *MountPoint) Setup(mountLabel string, rootUID, rootGID int, checkFun fun
 		if err == nil {
 			if label.RelabelNeeded(m.Mode) {
 				if err = label.Relabel(m.Source, mountLabel, label.IsShared(m.Mode)); err != nil {
+					if err == syscall.ENOTSUP {
+						err = nil
+						return
+					}
 					path = ""
 					err = errors.Wrapf(err, "error setting label on mount source '%s'", m.Source)
 					return


### PR DESCRIPTION
Backport fix:
* moby/moby/pull/33831 Do not error on relabel when relabel not supported

With cherry-pick moby/moby@ebfdfc5:
```
$ git cherry-pick -s -x -Xsubtree=components/engine ebfdfc5
$ git cherry-pick -s -x -Xsubtree=components/cli/vendor/github.com/docker/docker ebfdfc5
```

No conflicts.