### PR TITLE
[17.06] Limit max backoff delay to 2 seconds for GRPC connection

### DIFF
--- a/components/engine/libcontainerd/remote_unix.go
+++ b/components/engine/libcontainerd/remote_unix.go
@@ -96,11 +96,13 @@ func New(stateDir string, options ...RemoteOption) (_ Remote, err error) {
 
 	// don't output the grpc reconnect logging
 	grpclog.SetLogger(log.New(ioutil.Discard, "", log.LstdFlags))
-	dialOpts := append([]grpc.DialOption{grpc.WithInsecure()},
+	dialOpts := []grpc.DialOption{
+		grpc.WithInsecure(),
+		grpc.WithBackoffMaxDelay(2 * time.Second),
 		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
 			return net.DialTimeout("unix", addr, timeout)
 		}),
-	)
+	}
 	conn, err := grpc.Dial(r.rpcAddr, dialOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("error connecting to containerd: %v", err)


### PR DESCRIPTION
Backport fix:
* moby/moby/pull/33483 Limit max backoff delay to 2 seconds for GRPC connection