### PR TITLE
[17.06] Fix stderr logging for journald and syslog

### DIFF
--- a/components/engine/daemon/logger/journald/journald.go
+++ b/components/engine/daemon/logger/journald/journald.go
@@ -112,9 +112,10 @@ func (s *journald) Log(msg *logger.Message) error {
 	}
 
 	line := string(msg.Line)
+	source := msg.Source
 	logger.PutMessage(msg)
 
-	if msg.Source == "stderr" {
+	if source == "stderr" {
 		return journal.Send(line, journal.PriErr, vars)
 	}
 	return journal.Send(line, journal.PriInfo, vars)

--- a/components/engine/daemon/logger/syslog/syslog.go
+++ b/components/engine/daemon/logger/syslog/syslog.go
@@ -133,8 +133,9 @@ func New(info logger.Info) (logger.Logger, error) {
 
 func (s *syslogger) Log(msg *logger.Message) error {
 	line := string(msg.Line)
+	source := msg.Source
 	logger.PutMessage(msg)
-	if msg.Source == "stderr" {
+	if source == "stderr" {
 		return s.writer.Err(line)
 	}
 	return s.writer.Info(line)


### PR DESCRIPTION
Backport fix:
* moby/moby/pull/33832 Fix stderr logging for journald and syslog

With cherry-pick moby/moby@917050c:
```
$ git cherry-pick -s -x -Xsubtree=components/engine 917050c
```

No conflicts.