### PR TITLE
[17.06] progress: Show progress of replicated tasks before they are assigned

### DIFF
--- a/components/cli/cli/command/service/progress/progress.go
+++ b/components/cli/cli/command/service/progress/progress.go
@@ -275,7 +275,11 @@ func (u *replicatedProgressUpdater) update(service swarm.Service, tasks []swarm.
 				continue
 			}
 		}
-		if _, nodeActive := activeNodes[task.NodeID]; nodeActive {
+		if task.NodeID != "" {
+			if _, nodeActive := activeNodes[task.NodeID]; nodeActive {
+				tasksBySlot[task.Slot] = task
+			}
+		} else {
 			tasksBySlot[task.Slot] = task
 		}
 	}


### PR DESCRIPTION
Backport fix:
* docker/cli/pull/237 progress: Show progress of replicated tasks before they are assigned