### PR TITLE
[17.06] backport various completion script updates

### DIFF
--- a/components/cli/contrib/completion/bash/docker
+++ b/components/cli/contrib/completion/bash/docker
@@ -2723,7 +2723,7 @@ _docker_network_create() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--attachable --aux-address --driver -d --gateway --help --internal --ip-range --ipam-driver --ipam-opt --ipv6 --label --opt -o --subnet" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--attachable --aux-address --driver -d --gateway --help --ingress --internal --ip-range --ipam-driver --ipam-opt --ipv6 --label --opt -o --subnet" -- "$cur" ) )
 			;;
 	esac
 }

--- a/components/cli/contrib/completion/bash/docker
+++ b/components/cli/contrib/completion/bash/docker
@@ -3039,6 +3039,7 @@ _docker_service_update() {
 _docker_service_update_and_create() {
 	local options_with_args="
 		--endpoint-mode
+		--entrypoint
 		--env -e
 		--force
 		--health-cmd
@@ -3138,7 +3139,7 @@ _docker_service_update_and_create() {
 	fi
 	if [ "$subcommand" = "update" ] ; then
 		options_with_args="$options_with_args
-			--arg
+			--args
 			--constraint-add
 			--constraint-rm
 			--container-label-add

--- a/components/cli/contrib/completion/bash/docker
+++ b/components/cli/contrib/completion/bash/docker
@@ -1413,7 +1413,7 @@ _docker_container_port() {
 _docker_container_prune() {
 	case "$prev" in
 		--filter)
-			COMPREPLY=( $( compgen -W "until" -S = -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "label label! until" -S = -- "$cur" ) )
 			__docker_nospace
 			return
 			;;
@@ -2428,7 +2428,7 @@ _docker_image_ls() {
 _docker_image_prune() {
 	case "$prev" in
 		--filter)
-			COMPREPLY=( $( compgen -W "until" -S = -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "label label! until" -S = -- "$cur" ) )
 			__docker_nospace
 			return
 			;;
@@ -2806,7 +2806,7 @@ _docker_network_ls() {
 _docker_network_prune() {
 	case "$prev" in
 		--filter)
-			COMPREPLY=( $( compgen -W "until" -S = -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "label label! until" -S = -- "$cur" ) )
 			__docker_nospace
 			return
 			;;
@@ -4314,7 +4314,7 @@ _docker_system_info() {
 _docker_system_prune() {
 	case "$prev" in
 		--filter)
-			COMPREPLY=( $( compgen -W "until" -S = -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "label label! until" -S = -- "$cur" ) )
 			__docker_nospace
 			return
 			;;
@@ -4433,9 +4433,17 @@ _docker_volume_ls() {
 }
 
 _docker_volume_prune() {
+	case "$prev" in
+		--filter)
+			COMPREPLY=( $( compgen -W "label label!" -S = -- "$cur" ) )
+			__docker_nospace
+			return
+			;;
+	esac
+
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--force -f --help" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--filter --force -f --help" -- "$cur" ) )
 			;;
 	esac
 }

--- a/components/cli/contrib/completion/bash/docker
+++ b/components/cli/contrib/completion/bash/docker
@@ -4240,13 +4240,16 @@ _docker_system_events() {
 				destroy
 				detach
 				die
+				disable
 				disconnect
+				enable
 				exec_create
 				exec_detach
 				exec_start
 				export
 				health_status
 				import
+				install
 				kill
 				load
 				mount
@@ -4255,6 +4258,7 @@ _docker_system_events() {
 				pull
 				push
 				reload
+				remove
 				rename
 				resize
 				restart
@@ -4280,7 +4284,7 @@ _docker_system_events() {
 			return
 			;;
 		type)
-			COMPREPLY=( $( compgen -W "container daemon image network volume" -- "${cur##*=}" ) )
+			COMPREPLY=( $( compgen -W "container daemon image network plugin volume" -- "${cur##*=}" ) )
 			return
 			;;
 		volume)

--- a/components/cli/contrib/completion/bash/docker
+++ b/components/cli/contrib/completion/bash/docker
@@ -3349,6 +3349,10 @@ _docker_swarm_init() {
 		--cert-expiry|--dispatcher-heartbeat|--external-ca|--max-snapshots|--snapshot-interval|--task-history-limit)
 			return
 			;;
+		--data-path-addr)
+			__docker_complete_local_interfaces
+			return
+			;;
 		--listen-addr)
 			if [[ $cur == *: ]] ; then
 				COMPREPLY=( $( compgen -W "2377" -- "${cur##*:}" ) )
@@ -3362,7 +3366,7 @@ _docker_swarm_init() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--advertise-addr --data-path-addr --autolock --availability --cert-expiry --dispatcher-heartbeat --external-ca --force-new-cluster --help --listen-addr --max-snapshots --snapshot-interval --task-history-limit" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--advertise-addr --autolock --availability --cert-expiry --data-path-addr --dispatcher-heartbeat --external-ca --force-new-cluster --help --listen-addr --max-snapshots --snapshot-interval --task-history-limit" -- "$cur" ) )
 			;;
 	esac
 }
@@ -3378,6 +3382,14 @@ _docker_swarm_join() {
 			fi
 			return
 			;;
+		--availability)
+			COMPREPLY=( $( compgen -W "active drain pause" -- "$cur" ) )
+			return
+			;;
+		--data-path-addr)
+			__docker_complete_local_interfaces
+			return
+			;;
 		--listen-addr)
 			if [[ $cur == *: ]] ; then
 				COMPREPLY=( $( compgen -W "2377" -- "${cur##*:}" ) )
@@ -3387,10 +3399,6 @@ _docker_swarm_join() {
 			fi
 			return
 			;;
-		--availability)
-			COMPREPLY=( $( compgen -W "active drain pause" -- "$cur" ) )
-			return
-			;;
 		--token)
 			return
 			;;
@@ -3398,7 +3406,7 @@ _docker_swarm_join() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--advertise-addr --data-path-addr --availability --help --listen-addr --token" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--advertise-addr --availability --data-path-addr --help --listen-addr --token" -- "$cur" ) )
 			;;
 		*:)
 			COMPREPLY=( $( compgen -W "2377" -- "${cur##*:}" ) )

--- a/components/cli/contrib/completion/bash/docker
+++ b/components/cli/contrib/completion/bash/docker
@@ -2704,7 +2704,7 @@ _docker_network_connect() {
 
 _docker_network_create() {
 	case "$prev" in
-		--aux-address|--gateway|--internal|--ip-range|--ipam-opt|--ipv6|--opt|-o|--subnet)
+		--aux-address|--gateway|--ip-range|--ipam-opt|--ipv6|--opt|-o|--subnet)
 			return
 			;;
 		--config-from)

--- a/components/cli/contrib/completion/bash/docker
+++ b/components/cli/contrib/completion/bash/docker
@@ -2707,8 +2707,8 @@ _docker_network_create() {
 		--aux-address|--gateway|--internal|--ip-range|--ipam-opt|--ipv6|--opt|-o|--subnet)
 			return
 			;;
-		--ipam-driver)
-			COMPREPLY=( $( compgen -W "default" -- "$cur" ) )
+		--config-from)
+			__docker_complete_networks
 			return
 			;;
 		--driver|-d)
@@ -2716,14 +2716,22 @@ _docker_network_create() {
 			__docker_complete_plugins_bundled --type Network --remove host --remove null --add macvlan
 			return
 			;;
+		--ipam-driver)
+			COMPREPLY=( $( compgen -W "default" -- "$cur" ) )
+			return
+			;;
 		--label)
+			return
+			;;
+		--scope)
+			COMPREPLY=( $( compgen -W "local swarm" -- "$cur" ) )
 			return
 			;;
 	esac
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--attachable --aux-address --driver -d --gateway --help --ingress --internal --ip-range --ipam-driver --ipam-opt --ipv6 --label --opt -o --subnet" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--attachable --aux-address --config-from --config-only --driver -d --gateway --help --ingress --internal --ip-range --ipam-driver --ipam-opt --ipv6 --label --opt -o --scope --subnet" -- "$cur" ) )
 			;;
 	esac
 }

--- a/components/cli/contrib/completion/bash/docker
+++ b/components/cli/contrib/completion/bash/docker
@@ -3074,6 +3074,7 @@ _docker_service_update_and_create() {
 		--rollback-failure-action
 		--rollback-max-failure-ratio
 		--rollback-monitor
+		--rollback-order
 		--rollback-parallelism
 		--stop-grace-period
 		--stop-signal
@@ -3081,6 +3082,7 @@ _docker_service_update_and_create() {
 		--update-failure-action
 		--update-max-failure-ratio
 		--update-monitor
+		--update-order
 		--update-parallelism
 		--user -u
 		--workdir -w
@@ -3248,6 +3250,10 @@ _docker_service_update_and_create() {
 			;;
 		--update-failure-action)
 			COMPREPLY=( $( compgen -W "continue pause rollback" -- "$cur" ) )
+			return
+			;;
+		--update-order|--rollback-order)
+			COMPREPLY=( $( compgen -W "start-first stop-first" -- "$cur" ) )
 			return
 			;;
 		--user|-u)

--- a/components/cli/contrib/completion/bash/docker
+++ b/components/cli/contrib/completion/bash/docker
@@ -3062,7 +3062,6 @@ _docker_service_update_and_create() {
 		--log-driver
 		--log-opt
 		--mount
-		--network
 		--replicas
 		--reserve-cpu
 		--reserve-memory
@@ -3111,6 +3110,7 @@ _docker_service_update_and_create() {
 			--host
 			--mode
 			--name
+			--network
 			--placement-pref
 			--publish -p
 			--secret

--- a/components/cli/contrib/completion/bash/docker
+++ b/components/cli/contrib/completion/bash/docker
@@ -3087,6 +3087,7 @@ _docker_service_update_and_create() {
 	"
 
 	local boolean_options="
+		--detach -d
 		--help
 		--no-healthcheck
 		--read-only

--- a/components/cli/contrib/completion/bash/docker
+++ b/components/cli/contrib/completion/bash/docker
@@ -3166,6 +3166,8 @@ _docker_service_update_and_create() {
 			--host-add
 			--host-rm
 			--image
+			--network-add
+			--network-rm
 			--placement-pref-add
 			--placement-pref-rm
 			--publish-add
@@ -3190,6 +3192,10 @@ _docker_service_update_and_create() {
 				;;
 			--image)
 				__docker_complete_image_repos_and_tags
+				return
+				;;
+			--network-add|--network-rm)
+				__docker_complete_networks
 				return
 				;;
 			--placement-pref-add|--placement-pref-rm)

--- a/components/cli/contrib/completion/bash/docker
+++ b/components/cli/contrib/completion/bash/docker
@@ -3292,6 +3292,7 @@ _docker_service_update_and_create() {
 
 _docker_swarm() {
 	local subcommands="
+		ca
 		init
 		join
 		join-token
@@ -3308,6 +3309,24 @@ _docker_swarm() {
 			;;
 		*)
 			COMPREPLY=( $( compgen -W "$subcommands" -- "$cur" ) )
+			;;
+	esac
+}
+
+_docker_swarm_ca() {
+	case "$prev" in
+		--ca-cert|--ca-key)
+			_filedir
+			return
+			;;
+		--cert-expiry|--external-ca)
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--ca-cert --ca-key --cert-expiry --detach -d --external-ca --help --quiet -q --rotate" -- "$cur" ) )
 			;;
 	esac
 }


### PR DESCRIPTION
backport completion script fixes:

1. docker/cli/pull/239 Add bash completion for `docker network create --ingress`
2. docker/cli/pull/246 Add bash completion for `label` filter of `prune` commands
3. docker/cli/pull/247 Add bash completion for `service create|update --entrypoint`
4. docker/cli/pull/248 Add bash completion for `network create --scope|--config-only|config-from`
5. docker/cli/pull/249 Fix bash completion for `network create --internal`
6. docker/cli/pull/250 Add bash completion for `service create --detach`
7. docker/cli/pull/251 Add bash completion for plugin events
8. docker/cli/pull/256 Add bash completion for `service create|update (update|rollback)-order`
9. docker/cli/pull/257 Add bash completion for `service create|update --network-(add|rm)`
10. docker/cli/pull/268 Add bash completion for `swarm ca`
11. docker/cli/pull/269 Fix bash completion for `swarm init|join --data-path-addr`
12. docker/cli/pull/321 Remove bash completion for `service update --network`

with cherry-pick (each PR only had one commit):
```
$ git cherry-pick -s -x -Xsubtree=components/cli \
  e4f9ad7 8b99b65 e0462e8 22579ba 12dc9eb 8baef10 \
  f0f7150 71dd0e0 fa0f470 5bd00a5 fa4dc88 e7e77b5
```