### PR TITLE
[17.06] Docker wait hangs indefinitely for non-existent container (vendor)

### DIFF
--- a/components/cli/vendor/github.com/docker/docker/client/container_wait.go
+++ b/components/cli/vendor/github.com/docker/docker/client/container_wait.go
@@ -31,7 +31,7 @@ func (cli *Client) ContainerWait(ctx context.Context, containerID string, condit
 	}
 
 	resultC := make(chan container.ContainerWaitOKBody)
-	errC := make(chan error)
+	errC := make(chan error, 1)
 
 	query := url.Values{}
 	query.Set("condition", string(condition))


### PR DESCRIPTION
Backport fix:
* moby/moby/issues/33948 Docker wait hangs indefinitely for non-existent container

Into `components/cli/vendor/github.com/docker/docker` with cherry-pick moby/moby@4d2d2ea:
```
$ git cherry-pick -s -x -Xsubtree=components/cli/vendor/github.com/docker/docker 4d2d2ea
```

This fix was already included in 1dc2936 to `components/engine`, but is also needed in `components/cli/vendor`.