### PR TITLE
[17.06] backport fix "Stop trying to load images on an incompatible OS"

### DIFF
--- a/components/engine/image/tarexport/load.go
+++ b/components/engine/image/tarexport/load.go
@@ -397,11 +397,7 @@ func checkValidParent(img, parent *image.Image) bool {
 }
 
 func checkCompatibleOS(os string) error {
-	// TODO @jhowardmsft LCOW - revisit for simultaneous platforms
 	platform := runtime.GOOS
-	if system.LCOWSupported() {
-		platform = "linux"
-	}
 	// always compatible if the OS matches; also match an empty OS
 	if os == platform || os == "" {
 		return nil

--- a/components/engine/image/tarexport/load.go
+++ b/components/engine/image/tarexport/load.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution"

--- a/components/engine/image/tarexport/load.go
+++ b/components/engine/image/tarexport/load.go
@@ -77,6 +77,9 @@ func (l *tarexporter) Load(inTar io.ReadCloser, outStream io.Writer, quiet bool)
 		if err != nil {
 			return err
 		}
+		if err := checkCompatibleOS(img.OS); err != nil {
+			return err
+		}
 		var rootFS image.RootFS
 		rootFS = *img.RootFS
 		rootFS.DiffIDs = nil
@@ -275,8 +278,15 @@ func (l *tarexporter) legacyLoadImage(oldID, sourceDir string, loadedMap map[str
 		return err
 	}
 
-	var img struct{ Parent string }
+	var img struct {
+		OS     string
+		Parent string
+	}
 	if err := json.Unmarshal(imageJSON, &img); err != nil {
+		return err
+	}
+
+	if err := checkCompatibleOS(img.OS); err != nil {
 		return err
 	}
 
@@ -384,4 +394,21 @@ func checkValidParent(img, parent *image.Image) bool {
 		}
 	}
 	return true
+}
+
+func checkCompatibleOS(os string) error {
+	// TODO @jhowardmsft LCOW - revisit for simultaneous platforms
+	platform := runtime.GOOS
+	if system.LCOWSupported() {
+		platform = "linux"
+	}
+	// always compatible if the OS matches; also match an empty OS
+	if os == platform || os == "" {
+		return nil
+	}
+	// for compatibility, only fail if the image or runtime OS is Windows
+	if os == "windows" || platform == "windows" {
+		return fmt.Errorf("cannot load %s image on %s", os, platform)
+	}
+	return nil
 }


### PR DESCRIPTION
Backport fix:
* moby/moby/pull/33647 Stop trying to load images on an incompatible OS

With cherry-pick of moby/moby@b9255e4:
```
$ git cherry-pick -s -x -Xsubtree=components/engine b9255e4
```

No need to cherry-pick into `componetns/cli/vendor` because file is not used by the client.