### PR TITLE
[17.06] backport (cli) Don't prune volumes on docker system prune

### DIFF
--- a/components/cli/cli/command/system/prune.go
+++ b/components/cli/cli/command/system/prune.go
@@ -1,7 +1,9 @@
 package system
 
 import (
+	"bytes"
 	"fmt"
+	"text/template"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
@@ -43,28 +45,14 @@ func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
 	return cmd
 }
 
-const (
-	warning = `WARNING! This will remove:
-	- all stopped containers
-	- all volumes not used by at least one container
-	- all networks not used by at least one container
-	%s
+const confirmationTemplate = `WARNING! This will remove:
+{{- range $_, $warning := . }}
+        - {{ $warning }}
+{{- end }}
 Are you sure you want to continue?`
 
-	danglingImageDesc = "- all dangling images"
-	allImageDesc      = `- all images without at least one container associated to them`
-)
-
 func runPrune(dockerCli command.Cli, options pruneOptions) error {
-	var message string
-
-	if options.all {
-		message = fmt.Sprintf(warning, allImageDesc)
-	} else {
-		message = fmt.Sprintf(warning, danglingImageDesc)
-	}
-
-	if !options.force && !command.PromptForConfirmation(dockerCli.In(), dockerCli.Out(), message) {
+	if !options.force && !command.PromptForConfirmation(dockerCli.In(), dockerCli.Out(), confirmationMessage(options)) {
 		return nil
 	}
 
@@ -100,4 +88,27 @@ func runPrune(dockerCli command.Cli, options pruneOptions) error {
 	fmt.Fprintln(dockerCli.Out(), "Total reclaimed space:", units.HumanSize(float64(spaceReclaimed)))
 
 	return nil
+}
+
+// confirmationMessage constructs a confirmation message that depends on the cli options.
+func confirmationMessage(options pruneOptions) string {
+	t := template.Must(template.New("confirmation message").Parse(confirmationTemplate))
+
+	warnings := []string{
+		"all stopped containers",
+		"all networks not used by at least one container",
+	}
+	if options.pruneVolumes {
+		warnings = append(warnings, "all volumes not used by at least one container")
+	}
+	if options.all {
+		warnings = append(warnings, "all images without at least one container associated to them")
+	} else {
+		warnings = append(warnings, "all dangling images")
+	}
+	warnings = append(warnings, "all build cache")
+
+	var buffer bytes.Buffer
+	t.Execute(&buffer, &warnings)
+	return buffer.String()
 }


### PR DESCRIPTION
Backport from upstream PRs:
* docker/cli/pull/118 Don't prune volumes on `docker system prune`
* docker/cli/pull/255 system prune: only warn for volumes if --volumes is given

With cherry-pick docker/cli@37fd612 and docker/cli@849b0e9:
```
$ git cherry-pick -s -x -Xsubtree=components/cli 37fd612 849b0e9
```

Conflict with `components/cli/cli/command/system/prune.go` but was able to resolve by taking the cherry-pick's change set.