### PR TITLE
[17.06] backport (cli) If `docker swarm ca` is not called with the `--rotate` flag, warn if other flags are passed

### DIFF
--- a/components/cli/cli/command/swarm/ca.go
+++ b/components/cli/cli/command/swarm/ca.go
@@ -61,6 +61,11 @@ func runRotateCA(dockerCli command.Cli, flags *pflag.FlagSet, opts caOptions) er
 	}
 
 	if !opts.rotate {
+		for _, f := range []string{flagCACert, flagCAKey, flagCACert, flagExternalCA} {
+			if flags.Changed(f) {
+				return fmt.Errorf("`--%s` flag requires the `--rotate` flag to update the CA", f)
+			}
+		}
 		if swarmInspect.ClusterInfo.TLSInfo.TrustRoot == "" {
 			fmt.Fprintln(dockerCli.Out(), "No CA information available")
 		} else {
@@ -71,7 +76,7 @@ func runRotateCA(dockerCli command.Cli, flags *pflag.FlagSet, opts caOptions) er
 
 	genRootCA := true
 	spec := &swarmInspect.Spec
-	opts.mergeSwarmSpec(spec, flags)
+	opts.mergeSwarmSpec(spec, flags) // updates the spec given the cert expiry or external CA flag
 	if flags.Changed(flagCACert) {
 		spec.CAConfig.SigningCACert = opts.rootCACert.Contents()
 		genRootCA = false

--- a/components/cli/cli/command/swarm/ca.go
+++ b/components/cli/cli/command/swarm/ca.go
@@ -61,7 +61,7 @@ func runRotateCA(dockerCli command.Cli, flags *pflag.FlagSet, opts caOptions) er
 	}
 
 	if !opts.rotate {
-		for _, f := range []string{flagCACert, flagCAKey, flagCACert, flagExternalCA} {
+		for _, f := range []string{flagCACert, flagCAKey, flagCertExpiry, flagExternalCA} {
 			if flags.Changed(f) {
 				return fmt.Errorf("`--%s` flag requires the `--rotate` flag to update the CA", f)
 			}


### PR DESCRIPTION
Backport fix (each PR has just one git commit):
* docker/cli/pull/207 If `docker swarm ca` is not called with the `--rotate` flag, warn if other flags are passed
* docker/cli/pull/328 Fix warning in docker CLI when `swarm ca` is called with flags other than `--rotate`

With cherry-pick of docker/cli@32b43bc and docker/cli@4615c92:
```
$ git cherry-pick -s -x -Xsubtree=components/cli 32b43bc 4615c92
```

Conflict with `components/cli/cli/command/swarm/ca_test.go` in that the docker/cli@4615c92 cherry-pick wanted to modify it and it did not exist on the `17.06` branch. Resolved the conflict by not apply the diff to that file.