### PR TITLE
[17.06] re-vndr containerd to docker/containerd 6e23458

### DIFF
--- a/components/engine/vendor.conf
+++ b/components/engine/vendor.conf
@@ -103,7 +103,7 @@ google.golang.org/genproto b3e7c2fb04031add52c4817f53f43757ccbf9c18
 github.com/docker/docker-credential-helpers v0.5.0
 
 # containerd
-github.com/containerd/containerd cfb82a876ecc11b5ca0977d1733adbe58599088a
+github.com/containerd/containerd 6e23458c129b551d5c9871e5174f6b1b7f6d1170 https://github.com/docker/containerd
 github.com/tonistiigi/fifo 1405643975692217d6720f8b54aeee1bf2cd5cf4
 
 # cluster

--- a/components/engine/vendor/github.com/containerd/containerd/runtime/container_linux.go
+++ b/components/engine/vendor/github.com/containerd/containerd/runtime/container_linux.go
@@ -112,11 +112,11 @@ func i64Ptr(i int64) *int64   { return &i }
 func (c *container) UpdateResources(r *Resource) error {
 	sr := ocs.LinuxResources{
 		Memory: &ocs.LinuxMemory{
-			Limit:       u64Ptr(uint64(r.Memory)),
-			Reservation: u64Ptr(uint64(r.MemoryReservation)),
-			Swap:        u64Ptr(uint64(r.MemorySwap)),
-			Kernel:      u64Ptr(uint64(r.KernelMemory)),
-			KernelTCP:   u64Ptr(uint64(r.KernelTCPMemory)),
+			Limit:       i64Ptr(r.Memory),
+			Reservation: i64Ptr(r.MemoryReservation),
+			Swap:        i64Ptr(r.MemorySwap),
+			Kernel:      i64Ptr(r.KernelMemory),
+			KernelTCP:   i64Ptr(r.KernelTCPMemory),
 		},
 		CPU: &ocs.LinuxCPU{
 			Shares: u64Ptr(uint64(r.CPUShares)),

--- a/components/engine/vendor/github.com/containerd/containerd/runtime/process.go
+++ b/components/engine/vendor/github.com/containerd/containerd/runtime/process.go
@@ -262,9 +262,26 @@ func (p *process) handleSigkilledShim(rst uint32, rerr error) (uint32, error) {
 		}
 		if ppid == "1" {
 			logrus.Warnf("containerd: %s:%s shim died, killing associated process", p.container.id, p.id)
+			// Before sending SIGKILL to container, we need to make sure
+			// the container is not in Paused state. If the container is
+			// Paused, the container will not response to any signal
+			// we should Resume it after sending SIGKILL
+			var (
+				s    State
+				err1 error
+			)
+			if p.container != nil {
+				s, err1 = p.container.Status()
+			}
+
 			unix.Kill(p.pid, syscall.SIGKILL)
 			if err != nil && err != syscall.ESRCH {
 				return UnknownStatus, fmt.Errorf("containerd: unable to SIGKILL %s:%s (pid %v): %v", p.container.id, p.id, p.pid, err)
+			}
+			if p.container != nil {
+				if err1 == nil && s == Paused {
+					p.container.Resume()
+				}
 			}
 
 			// wait for the process to die
@@ -287,6 +304,17 @@ func (p *process) handleSigkilledShim(rst uint32, rerr error) (uint32, error) {
 	e := unix.Kill(p.cmd.Process.Pid, 0)
 	if e != syscall.ESRCH {
 		return rst, rerr
+	}
+
+	// The shim was SIGKILLED
+	// We should get the container state first
+	// to make sure the container is not in
+	// Pause state, if it's Paused, we should resume it
+	// and it will exit immediately because shim will send sigkill to
+	// container when died.
+	s, err1 := p.container.Status()
+	if err1 == nil && s == Paused {
+		p.container.Resume()
 	}
 
 	// Ensure we got the shim ProcessState


### PR DESCRIPTION
Re-vndr containerd to docker/containerd@6e23458

```
$ cd components/engine
$ make BIND_DIR=. shell
$ vndr github.com/containerd/containerd
2017/07/11 07:14:44 Collecting initial packages
2017/07/11 07:14:44 Download dependencies
2017/07/11 07:14:45     Clone https://github.com/docker/containerd to github.com/containerd/containerd, revision 6e23458c129b551d5c9871e5174f6b1b7f6d1170
2017/07/11 07:14:47     Finished clone github.com/containerd/containerd
2017/07/11 07:14:47 Dependencies downloaded. Download time: 1.549271645s
2017/07/11 07:14:47 Collecting all dependencies
2017/07/11 07:14:56 Clean vendor dir from unused packages
2017/07/11 07:14:56 Success
2017/07/11 07:14:56 Running time: 11.911349402s
```

To bring in changes from:
* docker/containerd/pull/4 17.06.1 chp

Note: there were 3 files that were deleted as a result of the `vndr` command:
```
        deleted:    vendor/github.com/spf13/cobra/doc/man_docs.go
        deleted:    vendor/github.com/spf13/cobra/doc/md_docs.go
        deleted:    vendor/github.com/spf13/cobra/doc/util.go
```

But I decided to leave them out of this PR. Will address in a separate PR.