### PR TITLE
[17.06.1] Backport engine userns secrets-mounting fix

### DIFF
--- a/components/engine/pkg/mount/mounter_linux.go
+++ b/components/engine/pkg/mount/mounter_linux.go
@@ -29,8 +29,9 @@ func isremount(device string, flags uintptr) bool {
 
 func mount(device, target, mType string, flags uintptr, data string) error {
 	oflags := flags &^ ptypes
-	if !isremount(device, flags) {
-		// Initial call applying all non-propagation flags.
+	if !isremount(device, flags) || data != "" {
+		// Initial call applying all non-propagation flags for mount
+		// or remount with changed data
 		if err := syscall.Mount(device, target, mType, oflags, data); err != nil {
 			return err
 		}


### PR DESCRIPTION
This is a backport of https://github.com/moby/moby/pull/34077. Cherry-pick moby/moby@3a1ab5b:

```
git cherry-pick -s -x -Xsubtree=components/engine 3a1ab5b
```

There was a conflict where it seems like the `syscall` had changed in engine master, but I just used the `syscall` import here.

cc @justincormack @tych0 @andrewhsu 