### PR TITLE
[17.07.x] Cherry pick new packaging commits

### DIFF
--- a/components/packaging/Makefile
+++ b/components/packaging/Makefile
@@ -2,6 +2,7 @@ SHELL:=/bin/bash
 ENGINE_DIR:=$(CURDIR)/../engine
 CLI_DIR:=$(CURDIR)/../cli
 VERSION=unknown
+PLUGIN_VERSION=unknown
 DOCKER_GITCOMMIT:=abcdefg
 
 .PHONY: help clean rpm deb static
@@ -17,17 +18,18 @@ clean: ## remove build artifacts
 rpm: DOCKER_BUILD_PKGS:=fedora-25 fedora-24 centos-7
 rpm: ## build rpm packages
 	for p in $(DOCKER_BUILD_PKGS); do \
-		$(MAKE) -C $@ VERSION=$(VERSION) ENGINE_DIR=$(ENGINE_DIR) CLI_DIR=$(CLI_DIR) $${p}; \
+		$(MAKE) -C $@ VERSION=$(VERSION) PLUGIN_VERSION=$(PLUGIN_VERSION) ENGINE_DIR=$(ENGINE_DIR) CLI_DIR=$(CLI_DIR) $${p}; \
 	done
 
 deb: DOCKER_BUILD_PKGS:=ubuntu-zesty ubuntu-yakkety ubuntu-xenial ubuntu-trusty debian-stretch debian-wheezy debian-jessie
 deb: ## build deb packages
+	$(MAKE) -C $@ metrics_plugin
 	for p in $(DOCKER_BUILD_PKGS); do \
-		$(MAKE) -C $@ VERSION=$(VERSION) ENGINE_DIR=$(ENGINE_DIR) CLI_DIR=$(CLI_DIR) $${p}; \
+		$(MAKE) -C $@ VERSION=$(VERSION) PLUGIN_VERSION=$(PLUGIN_VERSION) ENGINE_DIR=$(ENGINE_DIR) CLI_DIR=$(CLI_DIR) $${p}; \
 	done
 
 static: DOCKER_BUILD_PKGS:=static-linux cross-mac cross-win cross-arm
 static: ## build static-compiled packages
 	for p in $(DOCKER_BUILD_PKGS); do \
-		$(MAKE) -C $@ VERSION=$(VERSION) ENGINE_DIR=$(ENGINE_DIR) CLI_DIR=$(CLI_DIR) $${p}; \
+		$(MAKE) -C $@ VERSION=$(VERSION) PLUGIN_VERSION=$(PLUGIN_VERSION) ENGINE_DIR=$(ENGINE_DIR) CLI_DIR=$(CLI_DIR) $${p}; \
 	done

--- a/components/packaging/common/load-telemetry-plugin
+++ b/components/packaging/common/load-telemetry-plugin
@@ -1,0 +1,66 @@
+#!/usr/bin/env sh
+
+BASE=/var/lib/docker
+TAR_DIR=$BASE/plugins/tar
+
+# make sure that the directory exists
+mkdir -p $TAR_DIR
+
+# Create the engine UUID, if it doesn't exist
+# This will be eventually handled by the docker engine
+# ref. https://github.com/moby/moby/issues/33356
+if [ -f $BASE/engine_uuid ]; then
+    UUID=$(cat $BASE/engine_uuid)
+fi
+if [ -z ${UUID+x} ]; then
+    UUID=$(cat /proc/sys/kernel/random/uuid | tee $BASE/engine_uuid)
+fi
+
+# make sure that docker is running
+if ! printf "%s" "$DOCKER_OPTS" | grep -qE -e '-H|--host'; then
+        DOCKER_SOCKET=/var/run/docker.sock
+else
+        DOCKER_SOCKET=$(printf "%s" "$DOCKER_OPTS" | grep -oP -e '(-H|--host)\W*unix://\K(\S+)' | sed 1q)
+fi
+
+if [ -n "$DOCKER_SOCKET" ]; then
+        while ! [ -e "$DOCKER_SOCKET" ]; do
+                sleep 0.1
+        done
+fi
+
+# store the metrics plugin state
+plugin_name=$(docker plugin ls | grep docker/telemetry | awk 'NR==1{print $2}')
+plugin_metadata=$TAR_DIR/.plugin-metadata
+if docker inspect $plugin_name > /dev/null 2>&1; then
+        plugin_state=$(docker plugin inspect $plugin_name | grep -o '"Enabled":.*' | sed 's/,/\\\}/g' | sed 's/ //g')
+        # remove previous plugin state
+        sed -i 's/,"Enabled":.*/\}/g' $plugin_metadata
+        # add new plugin state
+        sed -i "s/\}/,$plugin_state/g" $plugin_metadata
+fi
+
+# find plugin_name based on the tarball
+plugin_filename=$(ls $TAR_DIR/)
+plugin_tag=$(echo $plugin_filename | cut -d"_" -f2-)
+plugin_tag=${plugin_tag%.tgz}
+plugin_name=docker/telemetry:$plugin_tag
+# install/upgrade telemetry plugin in case it's not present (ignore stdout/stderror)
+if ! docker inspect $plugin_name > /dev/null 2>&1; then
+        # remove old plugin versions
+        docker plugin rm -f `docker plugin ls | grep docker/telemetry | awk '{print $2}'` > /dev/null 2>&1
+        # create new plugin (disabled by default)
+        cd $TAR_DIR/ && tar -zxf $plugin_filename -C /tmp
+        docker plugin create $plugin_name /tmp/plugin > /dev/null 2>&1
+        rm -rf /tmp/plugin
+        # extract all the edition variables, including the engine uuid
+        uuid=$(cat /var/lib/docker/engine_uuid)
+        edition_version=$(cat $plugin_metadata | sed 's/{.*edition_version":"*\([0-9a-zA-Z.]*\)"*,*.*}/\1/')
+        edition_type=$(cat $plugin_metadata | sed 's/{.*edition_type":"*\([0-9a-zA-Z.]*\)"*,*.*}/\1/')
+        edition_name=$(cat $plugin_metadata | sed 's/{.*edition_name":"*\([0-9a-zA-Z.]*\)"*,*.*}/\1/')
+        docker plugin set $plugin_name edition_name=$edition_name edition_type=$edition_type edition_version=$edition_version anonymous_id=$uuid > /dev/null 2>&1
+        # set the metrics plugin to its previous state
+        if grep 'true' $plugin_metadata > /dev/null 2>&1 ; then
+                docker plugin enable $plugin_name > /dev/null 2>&1
+        fi
+fi

--- a/components/packaging/deb/Makefile
+++ b/components/packaging/deb/Makefile
@@ -1,10 +1,14 @@
 SHELL:=/bin/bash
 ALPINE_IMG:=$(shell $(CURDIR)/../detect_alpine_image)
 ARCH:=$(shell uname -m)
+KERNEL:=$(shell docker version --format '{{.Server.Os}}')
 ENGINE_DIR:=$(CURDIR)/../../engine
 CLI_DIR:=$(CURDIR)/../../cli
+COMMON_DIR:=$(CURDIR)/../common
+PLUGIN_DIR:=$(CURDIR)/plugin
 GITCOMMIT?=$(shell cd $(ENGINE_DIR) && git rev-parse --short HEAD)
 VERSION?=$(shell cat $(ENGINE_DIR)/VERSION)
+PLUGIN_VERSION?=1.0.0.$(KERNEL)-$(ARCH)-test
 DOCKER_EXPERIMENTAL:=0
 CHOWN:=docker run --rm -v $(CURDIR):/v -w /v $(ALPINE_IMG) chown
 
@@ -23,15 +27,24 @@ ubuntu: ubuntu-zesty ubuntu-yakkety ubuntu-xenial ubuntu-trusty ## build all ubu
 
 debian: debian-stretch debian-wheezy debian-jessie ## build all debian deb packages
 
+metrics_plugin: ## pull telemetry plugin tarball
+	mkdir -p $(PLUGIN_DIR)
+	docker create --name tmp docker/telemetry-tgz:$(PLUGIN_VERSION)
+	docker export tmp | tar -x -C $(PLUGIN_DIR)
+	docker rm -f tmp
+
 ubuntu-xenial: ## build ubuntu xenial deb packages
 	docker build -t debbuild-$@/$(ARCH) -f $(CURDIR)/$@/Dockerfile.$(ARCH) .
 	docker run --rm -i \
 		-e VERSION=$(VERSION) \
+		-e PLUGIN_VERSION=$(PLUGIN_VERSION) \
 		-e DOCKER_GITCOMMIT=$(GITCOMMIT) \
 		-v $(CURDIR)/debbuild/$@:/build \
 		-v $(ENGINE_DIR):/engine \
+		-v $(PLUGIN_DIR):/plugin \
 		-v $(CLI_DIR):/cli \
 		-v $(CURDIR)/systemd:/root/build-deb/systemd \
+		-v $(COMMON_DIR):/root/build-deb/common \
 		debbuild-$@/$(ARCH)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
 
@@ -39,11 +52,14 @@ ubuntu-trusty: ## build ubuntu trusty deb packages
 	docker build -t debbuild-$@/$(ARCH) -f $(CURDIR)/$@/Dockerfile.$(ARCH) .
 	docker run --rm -i \
 		-e VERSION=$(VERSION) \
+		-e PLUGIN_VERSION=$(PLUGIN_VERSION) \
 		-e DOCKER_GITCOMMIT=$(GITCOMMIT) \
 		-v $(CURDIR)/debbuild/$@:/build \
 		-v $(ENGINE_DIR):/engine \
+		-v $(PLUGIN_DIR):/plugin \
 		-v $(CLI_DIR):/cli \
 		-v $(CURDIR)/systemd:/root/build-deb/systemd \
+		-v $(COMMON_DIR):/root/build-deb/common \
 		debbuild-$@/$(ARCH)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
 
@@ -52,10 +68,13 @@ ubuntu-yakkety: ## build ubuntu yakkety deb packages
 	docker run --rm -i \
 		-e VERSION=$(VERSION) \
 		-e DOCKER_GITCOMMIT=$(GITCOMMIT) \
+		-e PLUGIN_VERSION=$(PLUGIN_VERSION) \
 		-v $(CURDIR)/debbuild/$@:/build \
 		-v $(ENGINE_DIR):/engine \
+		-v $(PLUGIN_DIR):/plugin \
 		-v $(CLI_DIR):/cli \
 		-v $(CURDIR)/systemd:/root/build-deb/systemd \
+		-v $(COMMON_DIR):/root/build-deb/common \
 		debbuild-$@/$(ARCH)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
 
@@ -64,10 +83,13 @@ ubuntu-zesty: ## build ubuntu zesty deb packages
 	docker run --rm -i \
 		-e VERSION=$(VERSION) \
 		-e DOCKER_GITCOMMIT=$(GITCOMMIT) \
+		-e PLUGIN_VERSION=$(PLUGIN_VERSION) \
 		-v $(CURDIR)/debbuild/$@:/build \
 		-v $(ENGINE_DIR):/engine \
+		-v $(PLUGIN_DIR):/plugin \
 		-v $(CLI_DIR):/cli \
 		-v $(CURDIR)/systemd:/root/build-deb/systemd \
+		-v $(COMMON_DIR):/root/build-deb/common \
 		debbuild-$@/$(ARCH)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
 
@@ -76,10 +98,13 @@ debian-jessie: ## build debian jessie deb packages
 	docker run --rm -i \
 		-e VERSION=$(VERSION) \
 		-e DOCKER_GITCOMMIT=$(GITCOMMIT) \
+		-e PLUGIN_VERSION=$(PLUGIN_VERSION) \
 		-v $(CURDIR)/debbuild/$@:/build \
 		-v $(ENGINE_DIR):/engine \
+		-v $(PLUGIN_DIR):/plugin \
 		-v $(CLI_DIR):/cli \
 		-v $(CURDIR)/systemd:/root/build-deb/systemd \
+		-v $(COMMON_DIR):/root/build-deb/common \
 		debbuild-$@/$(ARCH)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
 
@@ -88,10 +113,13 @@ debian-stretch: ## build debian stretch deb packages
 	docker run --rm -i \
 		-e VERSION=$(VERSION) \
 		-e DOCKER_GITCOMMIT=$(GITCOMMIT) \
+		-e PLUGIN_VERSION=$(PLUGIN_VERSION) \
 		-v $(CURDIR)/debbuild/$@:/build \
 		-v $(ENGINE_DIR):/engine \
+		-v $(PLUGIN_DIR):/plugin \
 		-v $(CLI_DIR):/cli \
 		-v $(CURDIR)/systemd:/root/build-deb/systemd \
+		-v $(COMMON_DIR):/root/build-deb/common \
 		debbuild-$@/$(ARCH)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
 
@@ -100,9 +128,12 @@ debian-wheezy: ## build debian wheezy deb packages
 	docker run --rm -i \
 		-e VERSION=$(VERSION) \
 		-e DOCKER_GITCOMMIT=$(GITCOMMIT) \
+		-e PLUGIN_VERSION=$(PLUGIN_VERSION) \
 		-v $(CURDIR)/debbuild/$@:/build \
 		-v $(ENGINE_DIR):/engine \
+		-v $(PLUGIN_DIR):/plugin \
 		-v $(CLI_DIR):/cli \
 		-v $(CURDIR)/systemd:/root/build-deb/systemd \
+		-v $(COMMON_DIR):/root/build-deb/common \
 		debbuild-$@/$(ARCH)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@

--- a/components/packaging/deb/common/docker-ce.docker.init
+++ b/components/packaging/deb/common/docker-ce.docker.init
@@ -85,7 +85,7 @@ cgroupfs_mount() {
 case "$1" in
 	start)
 		check_init
-		
+
 		fail_unless_root
 
 		cgroupfs_mount
@@ -114,6 +114,8 @@ case "$1" in
 				$DOCKER_OPTS \
 					>> "$DOCKER_LOGFILE" 2>&1
 		log_end_msg $?
+		# load metrics plugin (disabled by default)
+		/usr/bin/load-telemetry-plugin
 		;;
 
 	stop)

--- a/components/packaging/deb/common/docker-ce.docker.upstart
+++ b/components/packaging/deb/common/docker-ce.docker.upstart
@@ -69,4 +69,6 @@ post-start script
 		done
 		echo "$DOCKER_SOCKET is up"
 	fi
+	# load metrics plugin (disabled by default)
+	/usr/bin/load-telemetry-plugin
 end script

--- a/components/packaging/deb/common/rules
+++ b/components/packaging/deb/common/rules
@@ -11,6 +11,8 @@ override_dh_gencontrol:
 	dh_gencontrol
 
 override_dh_auto_build:
+	# create metrics plugin metadata
+	printf '{"edition_type":"ce","edition_name":"%s","edition_version":"%s"}\n' "$(DISTRO)" "$(VERSION)" > /plugin/.plugin-metadata
 	cd engine && ./hack/make.sh dynbinary
 	LDFLAGS='' make -C cli VERSION=$(VERSION) GITCOMMIT=$(DOCKER_GITCOMMIT) dynbinary manpages
 
@@ -31,6 +33,10 @@ override_dh_auto_install:
 	cp -aT /usr/local/bin/docker-runc debian/docker-ce/usr/bin/docker-runc
 	cp -aT /usr/local/bin/docker-init debian/docker-ce/usr/bin/docker-init
 	mkdir -p debian/docker-ce/usr/lib/docker
+	mkdir -p debian/docker-ce/var/lib/docker/plugins/tar
+	cp -aTL /plugin/telemetry_$(PLUGIN_VERSION).tgz debian/docker-ce/var/lib/docker/plugins/tar/telemetry_$(PLUGIN_VERSION).tgz
+	cp -aTL /plugin/.plugin-metadata debian/docker-ce/var/lib/docker/plugins/tar/.plugin-metadata
+	cp -aTL /root/build-deb/common/load-telemetry-plugin debian/docker-ce/usr/bin/load-telemetry-plugin
 
 override_dh_installinit:
 	# use "docker" as our service name, not "docker-ce"

--- a/components/packaging/deb/common/rules
+++ b/components/packaging/deb/common/rules
@@ -14,7 +14,7 @@ override_dh_auto_build:
 	# create metrics plugin metadata
 	printf '{"edition_type":"ce","edition_name":"%s","edition_version":"%s"}\n' "$(DISTRO)" "$(VERSION)" > /plugin/.plugin-metadata
 	cd engine && ./hack/make.sh dynbinary
-	LDFLAGS='' make -C cli VERSION=$(VERSION) GITCOMMIT=$(DOCKER_GITCOMMIT) dynbinary manpages
+	cd /go/src/github.com/docker/cli && LDFLAGS='' make VERSION=$(VERSION) GITCOMMIT=$(DOCKER_GITCOMMIT) dynbinary manpages
 
 override_dh_auto_test:
 	./engine/bundles/$(BUNDLE_VERSION)/dynbinary-daemon/dockerd -v

--- a/components/packaging/deb/systemd/docker.service
+++ b/components/packaging/deb/systemd/docker.service
@@ -12,6 +12,7 @@ Type=notify
 # for containers run by docker
 ExecStart=/usr/bin/dockerd -H fd://
 ExecReload=/bin/kill -s HUP $MAINPID
+ExecStartPost=/usr/bin/load-telemetry-plugin
 LimitNOFILE=1048576
 # Having non-zero Limit*s causes performance problems due to accounting overhead
 # in the kernel. We recommend using cgroups to do container-local accounting.

--- a/components/packaging/rpm/Makefile
+++ b/components/packaging/rpm/Makefile
@@ -1,9 +1,13 @@
 ARCH=$(shell uname -m)
 ALPINE_IMG:=$(shell $(CURDIR)/../detect_alpine_image)
+KERNEL:=$(shell docker version --format '{{.Server.Os}}')
 ENGINE_DIR:=$(CURDIR)/../../engine
+COMMON_DIR:=$(CURDIR)/../common
+PLUGIN_DIR:=$(CURDIR)/plugin
 CLI_DIR:=$(CURDIR)/../../cli
 GITCOMMIT=$(shell cd $(ENGINE_DIR) && git rev-parse --short HEAD)
 VERSION=$(shell cat $(ENGINE_DIR)/VERSION)
+PLUGIN_VERSION?=1.0.0.$(KERNEL)-$(ARCH)-test
 DOCKER_EXPERIMENTAL=0
 GEN_RPM_VER=$(shell ./gen-rpm-ver $(ENGINE_DIR) $(VERSION))
 CHOWN=docker run --rm -i -v $(CURDIR):/v -w /v $(ALPINE_IMG) chown
@@ -13,11 +17,13 @@ RPMBUILD=docker run --privileged --rm -i\
 	-v $(CURDIR)/rpmbuild/BUILDROOT:/root/rpmbuild/BUILDROOT \
 	-v $(CURDIR)/rpmbuild/RPMS:/root/rpmbuild/RPMS \
 	-v $(CURDIR)/rpmbuild/SRPMS:/root/rpmbuild/SRPMS \
-	-v $(CURDIR)/systemd:/systemd
+	-v $(CURDIR)/systemd:/systemd \
+	-v $(COMMON_DIR):/common
 RPMBUILD_FLAGS=-ba\
 	--define '_gitcommit $(word 3,$(GEN_RPM_VER))' \
 	--define '_release $(word 2,$(GEN_RPM_VER))' \
 	--define '_version $(word 1,$(GEN_RPM_VER))' \
+	--define '_plugin_version $(PLUGIN_VERSION)' \
 	--define '_origversion $(VERSION)' \
 	--define '_experimental $(DOCKER_EXPERIMENTAL)' \
 	SPECS/docker-ce.spec
@@ -37,17 +43,17 @@ fedora: fedora-25 fedora-24 ## build all fedora rpm packages
 
 centos: centos-7 ## build all centos rpm packages
 
-fedora-25: rpmbuild/SOURCES/engine.tgz rpmbuild/SOURCES/cli.tgz ## build fedora-25 rpm packages
+fedora-25: rpmbuild/SOURCES/engine.tgz rpmbuild/SOURCES/cli.tgz rpmbuild/SOURCES/telemetry.tgz ## build fedora-25 rpm packages
 	docker build -t rpmbuild-$@/$(ARCH) -f $@/Dockerfile.$(ARCH) $@
 	$(RPMBUILD) rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
 
-fedora-24: rpmbuild/SOURCES/engine.tgz rpmbuild/SOURCES/cli.tgz ## build fedora-24 rpm packages
+fedora-24: rpmbuild/SOURCES/engine.tgz rpmbuild/SOURCES/cli.tgz rpmbuild/SOURCES/telemetry.tgz ## build fedora-24 rpm packages
 	docker build -t rpmbuild-$@/$(ARCH) -f $@/Dockerfile.$(ARCH) $@
 	$(RPMBUILD) rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
 
-centos-7: rpmbuild/SOURCES/engine.tgz rpmbuild/SOURCES/cli.tgz ## build centos-7 rpm packages
+centos-7: rpmbuild/SOURCES/engine.tgz rpmbuild/SOURCES/cli.tgz rpmbuild/SOURCES/telemetry.tgz ## build centos-7 rpm packages
 	docker build -t rpmbuild-$@/$(ARCH) -f $@/Dockerfile.$(ARCH) $@
 	$(RPMBUILD) rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
@@ -67,3 +73,15 @@ rpmbuild/SOURCES/engine.tgz:
 		-v $(CURDIR)/rpmbuild/SOURCES:/v \
 		$(ALPINE_IMG) \
 		tar -C / -c -z -f /v/engine.tgz --exclude .git engine
+
+rpmbuild/SOURCES/telemetry.tgz:
+	mkdir -p rpmbuild/SOURCES
+	mkdir -p $(PLUGIN_DIR)
+	docker create --name tmp docker/telemetry-tgz:$(PLUGIN_VERSION)
+	docker export tmp | tar -x -C $(PLUGIN_DIR)
+	docker run --rm -i -w /plugin \
+		-v $(PLUGIN_DIR):/plugin \
+		-v $(CURDIR)/rpmbuild/SOURCES:/v \
+		alpine \
+		cp telemetry_$(PLUGIN_VERSION).tgz /v
+	docker rm -f tmp

--- a/components/packaging/rpm/centos-7/docker-ce.spec
+++ b/components/packaging/rpm/centos-7/docker-ce.spec
@@ -6,6 +6,7 @@ Group: Tools/Docker
 License: ASL 2.0
 Source0: engine.tgz
 Source1: cli.tgz
+Source2: telemetry_%{_plugin_version}.tgz
 URL: https://www.docker.com
 Vendor: Docker
 Packager: Docker <support@docker.com>
@@ -68,6 +69,8 @@ pushd engine
 TMP_GOPATH="/go" hack/dockerfile/install-binaries.sh runc-dynamic containerd-dynamic proxy-dynamic tini
 hack/make.sh dynbinary
 popd
+mkdir -p plugin
+printf '{"edition_type":"ce","edition_name":"%s","edition_version":"%s"}\n' "${DISTRO}" "%{_version}" > plugin/.plugin-metadata
 
 %check
 cli/build/docker -v
@@ -138,6 +141,12 @@ for cli_file in LICENSE MAINTAINERS NOTICE README.md; do
     cp "cli/$cli_file" "build-docs/cli-$cli_file"
 done
 
+# add telemetry plugin
+install -d $RPM_BUILD_ROOT/var/lib/docker/plugins/tar
+install -p -m 644 %{SOURCE2} $RPM_BUILD_ROOT/var/lib/docker/plugins/tar
+install -p -m 644 plugin/.plugin-metadata $RPM_BUILD_ROOT/var/lib/docker/plugins/tar
+install -p -m 755 /common/load-telemetry-plugin $RPM_BUILD_ROOT/%{_bindir}/load-telemetry-plugin
+
 # list files owned by the package here
 %files
 %doc build-docs/engine-AUTHORS build-docs/engine-CHANGELOG.md build-docs/engine-CONTRIBUTING.md build-docs/engine-LICENSE build-docs/engine-MAINTAINERS build-docs/engine-NOTICE build-docs/engine-README.md
@@ -163,6 +172,9 @@ done
 /usr/share/vim/vimfiles/ftdetect/dockerfile.vim
 /usr/share/vim/vimfiles/syntax/dockerfile.vim
 /usr/share/nano/Dockerfile.nanorc
+/var/lib/docker/plugins/tar/telemetry_%{_plugin_version}.tgz
+/var/lib/docker/plugins/tar/.plugin-metadata
+/usr/bin/load-telemetry-plugin
 
 %pre
 if [ $1 -gt 0 ] ; then

--- a/components/packaging/rpm/fedora-24/docker-ce.spec
+++ b/components/packaging/rpm/fedora-24/docker-ce.spec
@@ -6,6 +6,7 @@ Group: Tools/Docker
 License: ASL 2.0
 Source0: engine.tgz
 Source1: cli.tgz
+Source2: telemetry_%{_plugin_version}.tgz
 URL: https://www.docker.com
 Vendor: Docker
 Packager: Docker <support@docker.com>
@@ -69,6 +70,8 @@ pushd engine
 TMP_GOPATH="/go" hack/dockerfile/install-binaries.sh runc-dynamic containerd-dynamic proxy-dynamic tini
 hack/make.sh dynbinary
 popd
+mkdir -p plugin
+printf '{"edition_type":"ce","edition_name":"%s","edition_version":"%s"}\n' "${DISTRO}" "%{_version}" > plugin/.plugin-metadata
 
 %check
 cli/build/docker -v
@@ -139,6 +142,12 @@ for cli_file in LICENSE MAINTAINERS NOTICE README.md; do
     cp "cli/$cli_file" "build-docs/cli-$cli_file"
 done
 
+# add telemetry plugin
+install -d $RPM_BUILD_ROOT/var/lib/docker/plugins/tar
+install -p -m 644 %{SOURCE2} $RPM_BUILD_ROOT/var/lib/docker/plugins/tar
+install -p -m 644 plugin/.plugin-metadata $RPM_BUILD_ROOT/var/lib/docker/plugins/tar
+install -p -m 755 /common/load-telemetry-plugin $RPM_BUILD_ROOT/%{_bindir}/load-telemetry-plugin
+
 # list files owned by the package here
 %files
 %doc build-docs/engine-AUTHORS build-docs/engine-CHANGELOG.md build-docs/engine-CONTRIBUTING.md build-docs/engine-LICENSE build-docs/engine-MAINTAINERS build-docs/engine-NOTICE build-docs/engine-README.md
@@ -164,6 +173,9 @@ done
 /usr/share/vim/vimfiles/ftdetect/dockerfile.vim
 /usr/share/vim/vimfiles/syntax/dockerfile.vim
 /usr/share/nano/Dockerfile.nanorc
+/var/lib/docker/plugins/tar/telemetry_%{_plugin_version}.tgz
+/var/lib/docker/plugins/tar/.plugin-metadata
+/usr/bin/load-telemetry-plugin
 
 %pre
 if [ $1 -gt 0 ] ; then

--- a/components/packaging/rpm/fedora-25/docker-ce.spec
+++ b/components/packaging/rpm/fedora-25/docker-ce.spec
@@ -6,6 +6,7 @@ Group: Tools/Docker
 License: ASL 2.0
 Source0: engine.tgz
 Source1: cli.tgz
+Source2: telemetry_%{_plugin_version}.tgz
 URL: https://www.docker.com
 Vendor: Docker
 Packager: Docker <support@docker.com>
@@ -67,6 +68,8 @@ pushd engine
 TMP_GOPATH="/go" hack/dockerfile/install-binaries.sh runc-dynamic containerd-dynamic proxy-dynamic tini
 hack/make.sh dynbinary
 popd
+mkdir -p plugin
+printf '{"edition_type":"ce","edition_name":"%s","edition_version":"%s"}\n' "${DISTRO}" "%{_version}" > plugin/.plugin-metadata
 
 %check
 cli/build/docker -v
@@ -137,6 +140,12 @@ for cli_file in LICENSE MAINTAINERS NOTICE README.md; do
     cp "cli/$cli_file" "build-docs/cli-$cli_file"
 done
 
+# add telemetry plugin
+install -d $RPM_BUILD_ROOT/var/lib/docker/plugins/tar
+install -p -m 644 %{SOURCE2} $RPM_BUILD_ROOT/var/lib/docker/plugins/tar
+install -p -m 644 plugin/.plugin-metadata $RPM_BUILD_ROOT/var/lib/docker/plugins/tar
+install -p -m 755 /common/load-telemetry-plugin $RPM_BUILD_ROOT/%{_bindir}/load-telemetry-plugin
+
 # list files owned by the package here
 %files
 %doc build-docs/engine-AUTHORS build-docs/engine-CHANGELOG.md build-docs/engine-CONTRIBUTING.md build-docs/engine-LICENSE build-docs/engine-MAINTAINERS build-docs/engine-NOTICE build-docs/engine-README.md
@@ -162,6 +171,9 @@ done
 /usr/share/vim/vimfiles/ftdetect/dockerfile.vim
 /usr/share/vim/vimfiles/syntax/dockerfile.vim
 /usr/share/nano/Dockerfile.nanorc
+/var/lib/docker/plugins/tar/telemetry_%{_plugin_version}.tgz
+/var/lib/docker/plugins/tar/.plugin-metadata
+/usr/bin/load-telemetry-plugin
 
 %pre
 if [ $1 -gt 0 ] ; then

--- a/components/packaging/rpm/systemd/docker.service
+++ b/components/packaging/rpm/systemd/docker.service
@@ -11,6 +11,7 @@ Type=notify
 # for containers run by docker
 ExecStart=/usr/bin/dockerd
 ExecReload=/bin/kill -s HUP $MAINPID
+ExecStartPost=/usr/bin/load-telemetry-plugin
 # Having non-zero Limit*s causes performance problems due to accounting overhead
 # in the kernel. We recommend using cgroups to do container-local accounting.
 LimitNOFILE=infinity


### PR DESCRIPTION
```shell
git cherry-pick -x -s -Xsubtree="components/packaging" ceac22b 3a548f8
```

Cherry picks:
* Added metrics plugin to RPM / DEB packaging, https://github.com/docker/docker-ce-packaging/pull/3
* Fix manpage generation for CLI in DEB packaging, https://github.com/docker/docker-ce-packaging/pull/37

Required for `aarch64` package building