### PR TITLE
[17.07.x] Add go-autogen to integration tests

### DIFF
--- a/components/engine/hack/make/test-integration-cli
+++ b/components/engine/hack/make/test-integration-cli
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
+source "${MAKEDIR}/.go-autogen"
 source hack/make/.integration-test-helpers
 
 # subshell so that we can export PATH without breaking other things


### PR DESCRIPTION
Picked from moby/moby#34206

```shell
git cherry-pick -x -s -Xsubtree="components/engine" 3cdd471
```

Integration test were failing in trial runs for docker-ce 17.07 due to
the lack of go-autogen being sourced in `hack/make.sh`. This re-adds
go-autogen to be sourced for test-integration-cli so that we can
actually run tests without the error found in:
https://github.com/moby/moby/pull/33857

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>
(cherry picked from commit 3cdd471cac8193c34d8483255065c6c28a7b1645)
Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>

CC @andrewhsu @thaJeztah @dnephin 