### PR TITLE
[17.07.x] Change make -C to a cd command

### DIFF
--- a/components/packaging/deb/common/rules
+++ b/components/packaging/deb/common/rules
@@ -12,7 +12,7 @@ override_dh_gencontrol:
 
 override_dh_auto_build:
 	cd engine && ./hack/make.sh dynbinary
-	LDFLAGS='' make -C cli VERSION=$(VERSION) GITCOMMIT=$(DOCKER_GITCOMMIT) dynbinary manpages
+	cd /go/src/github.com/docker/cli && LDFLAGS='' make VERSION=$(VERSION) GITCOMMIT=$(DOCKER_GITCOMMIT) dynbinary manpages
 
 override_dh_auto_test:
 	./engine/bundles/$(BUNDLE_VERSION)/dynbinary-daemon/dockerd -v


### PR DESCRIPTION
```shell
git cherry-pick -x -s -Xsubtree="components/packaging" 3a548f8
```

Cherry-picked from docker/docker-ce-packaging#37

## PR Text
Tried out make -C in this scenario and it did not seem to function
correctly, changed to cd.

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>
(cherry picked from commit 3a548f8815d5308b197abea1e39f0a0a4939c4f2)
Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>

CC @andrewhsu 