### PR TITLE
[17.06] Set unpaused state when receiving 'stateExit' event

### DIFF
--- a/components/engine/container/state.go
+++ b/components/engine/container/state.go
@@ -278,6 +278,7 @@ func (s *State) SetRunning(pid int, initial bool) {
 	s.ErrorMsg = ""
 	s.Running = true
 	s.Restarting = false
+	s.Paused = false
 	s.ExitCodeValue = 0
 	s.Pid = pid
 	if initial {
@@ -304,6 +305,7 @@ func (s *State) SetRestarting(exitStatus *ExitStatus) {
 	// all the checks in docker around rm/stop/etc
 	s.Running = true
 	s.Restarting = true
+	s.Paused = false
 	s.Pid = 0
 	s.FinishedAt = time.Now().UTC()
 	s.setFromExitStatus(exitStatus)

--- a/components/engine/container/state.go
+++ b/components/engine/container/state.go
@@ -278,7 +278,9 @@ func (s *State) SetRunning(pid int, initial bool) {
 	s.ErrorMsg = ""
 	s.Running = true
 	s.Restarting = false
-	s.Paused = false
+	if initial {
+		s.Paused = false
+	}
 	s.ExitCodeValue = 0
 	s.Pid = pid
 	if initial {


### PR DESCRIPTION
Backport fixes:
* moby/moby/pull/33843 Set unpaused state when receiving 'stateExit' event
* moby/moby/pull/34071 Keep pause state when restoring container's status

With cherry pick git commit moby/moby@fe1b4cf and moby/moby@977c404:
```
$ git cherry-pick -s -x -Xsubtree=components/engine fe1b4cf
$ git cherry-pick -s -x -Xsubtree=components/engine 977c404
```
No conflicts on both.