### PR TITLE
WIP [17.07] fix tests

### DIFF
--- a/components/cli/vendor/github.com/docker/docker/client/hijack.go
+++ b/components/cli/vendor/github.com/docker/docker/client/hijack.go
@@ -177,12 +177,14 @@ func (cli *Client) setupHijackConn(req *http.Request, proto string) (net.Conn, e
 
 	// Server hijacks the connection, error 'connection closed' expected
 	resp, err := clientconn.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode != http.StatusSwitchingProtocols {
-		resp.Body.Close()
-		return nil, fmt.Errorf("unable to upgrade to %s, received %d", proto, resp.StatusCode)
+	if err != httputil.ErrPersistEOF {
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode != http.StatusSwitchingProtocols {
+			resp.Body.Close()
+			return nil, fmt.Errorf("unable to upgrade to %s, received %d", proto, resp.StatusCode)
+		}
 	}
 
 	c, br := clientconn.Hijack()

--- a/components/engine/client/hijack.go
+++ b/components/engine/client/hijack.go
@@ -177,12 +177,14 @@ func (cli *Client) setupHijackConn(req *http.Request, proto string) (net.Conn, e
 
 	// Server hijacks the connection, error 'connection closed' expected
 	resp, err := clientconn.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode != http.StatusSwitchingProtocols {
-		resp.Body.Close()
-		return nil, fmt.Errorf("unable to upgrade to %s, received %d", proto, resp.StatusCode)
+	if err != httputil.ErrPersistEOF {
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode != http.StatusSwitchingProtocols {
+			resp.Body.Close()
+			return nil, fmt.Errorf("unable to upgrade to %s, received %d", proto, resp.StatusCode)
+		}
 	}
 
 	c, br := clientconn.Hijack()

--- a/components/engine/integration-cli/docker_cli_rmi_test.go
+++ b/components/engine/integration-cli/docker_cli_rmi_test.go
@@ -243,7 +243,7 @@ func (s *DockerSuite) TestRmiContainerImageNotFound(c *check.C) {
 	dockerCmd(c, "rmi", "-f", imageIds[1])
 
 	// Try to remove the image of the running container and see if it fails as expected.
-	out, _, err := dockerCmdWithError("rmi", "-f", imageIds[0])
+	out, _, err := dockerCmdWithError("rmi", imageIds[0])
 	// The image of the running container should not be removed.
 	c.Assert(err, checker.NotNil)
 	c.Assert(out, checker.Contains, "image is being used by running container", check.Commentf("out: %s", out))

--- a/components/engine/integration-cli/docker_cli_rmi_test.go
+++ b/components/engine/integration-cli/docker_cli_rmi_test.go
@@ -150,8 +150,8 @@ func (s *DockerSuite) TestRmiImageIDForceWithRunningContainersAndMultipleTags(c 
 	dockerCmd(c, "tag", imgID, newTag)
 	runSleepingContainerInImage(c, imgID)
 
-	out, _, err := dockerCmdWithError("rmi", "-f", imgID)
-	// rmi -f should not delete image with running containers
+	out, _, err := dockerCmdWithError("rmi", imgID)
+	// rmi should not delete image with running containers
 	c.Assert(err, checker.NotNil)
 	c.Assert(out, checker.Contains, "(cannot be forced) - image is being used by running container")
 }

--- a/components/engine/integration-cli/docker_cli_run_unix_test.go
+++ b/components/engine/integration-cli/docker_cli_run_unix_test.go
@@ -1564,7 +1564,7 @@ func (s *DockerSuite) TestRunWithNanoCPUs(c *check.C) {
 	c.Assert(strings.TrimSpace(out), checker.Equals, "50000\n100000")
 
 	out = inspectField(c, "test", "HostConfig.NanoCpus")
-	c.Assert(out, checker.Equals, "5e+08", check.Commentf("setting the Nano CPUs failed"))
+	c.Assert(out, checker.Equals, "500000000", check.Commentf("setting the Nano CPUs failed"))
 	out = inspectField(c, "test", "HostConfig.CpuQuota")
 	c.Assert(out, checker.Equals, "0", check.Commentf("CPU CFS quota should be 0"))
 	out = inspectField(c, "test", "HostConfig.CpuPeriod")

--- a/components/engine/integration-cli/docker_cli_service_logs_test.go
+++ b/components/engine/integration-cli/docker_cli_service_logs_test.go
@@ -40,7 +40,7 @@ func (s *DockerSwarmSuite) TestServiceLogs(c *check.C) {
 	// make sure task has been deployed.
 	waitAndAssert(c, defaultReconciliationTimeout,
 		d.CheckRunningTaskImages, checker.DeepEquals,
-		map[string]int{"busybox": len(services)})
+		map[string]int{"busybox:latest": len(services)})
 
 	for name, message := range services {
 		out, err := d.Cmd("service", "logs", name)

--- a/components/engine/integration-cli/docker_cli_swarm_test.go
+++ b/components/engine/integration-cli/docker_cli_swarm_test.go
@@ -1730,18 +1730,13 @@ func (s *DockerSwarmSuite) TestSwarmServicePsMultipleServiceIDs(c *check.C) {
 
 	// Name Prefix
 	out, err = d.Cmd("service", "ps", "to")
-	c.Assert(err, checker.IsNil)
-	c.Assert(out, checker.Contains, name1+".1")
-	c.Assert(out, checker.Contains, name1+".2")
-	c.Assert(out, checker.Contains, name1+".3")
-	c.Assert(out, checker.Contains, name2+".1")
-	c.Assert(out, checker.Contains, name2+".2")
-	c.Assert(out, checker.Contains, name2+".3")
+	c.Assert(err, checker.NotNil)
+	c.Assert(out, checker.Contains, "no such service: to")
 
 	// Name Prefix (no hit)
 	out, err = d.Cmd("service", "ps", "noname")
 	c.Assert(err, checker.NotNil)
-	c.Assert(out, checker.Contains, "no such services: noname")
+	c.Assert(out, checker.Contains, "no such service: noname")
 
 	out, err = d.Cmd("service", "ps", id1)
 	c.Assert(err, checker.IsNil)

--- a/components/engine/integration-cli/docker_cli_swarm_unix_test.go
+++ b/components/engine/integration-cli/docker_cli_swarm_unix_test.go
@@ -94,7 +94,7 @@ func (s *DockerSwarmSuite) TestSwarmNetworkPluginV2(c *check.C) {
 
 	time.Sleep(20 * time.Second)
 
-	image := "busybox"
+	image := "busybox:latest"
 	// create a new global service again.
 	_, err = d1.Cmd("service", "create", "--no-resolve-image", "--name", serviceName, "--mode=global", "--network", networkName, image, "top")
 	c.Assert(err, checker.IsNil)

--- a/components/engine/integration-cli/docker_cli_update_unix_test.go
+++ b/components/engine/integration-cli/docker_cli_update_unix_test.go
@@ -296,7 +296,7 @@ func (s *DockerSuite) TestUpdateWithNanoCPUs(c *check.C) {
 	c.Assert(strings.TrimSpace(out), checker.Equals, "50000\n100000")
 
 	out = inspectField(c, "top", "HostConfig.NanoCpus")
-	c.Assert(out, checker.Equals, "5e+08", check.Commentf("setting the Nano CPUs failed"))
+	c.Assert(out, checker.Equals, "500000000", check.Commentf("setting the Nano CPUs failed"))
 	out = inspectField(c, "top", "HostConfig.CpuQuota")
 	c.Assert(out, checker.Equals, "0", check.Commentf("CPU CFS quota should be 0"))
 	out = inspectField(c, "top", "HostConfig.CpuPeriod")

--- a/components/engine/integration-cli/docker_cli_update_unix_test.go
+++ b/components/engine/integration-cli/docker_cli_update_unix_test.go
@@ -308,7 +308,7 @@ func (s *DockerSuite) TestUpdateWithNanoCPUs(c *check.C) {
 
 	out, _ = dockerCmd(c, "update", "--cpus", "0.8", "top")
 	out = inspectField(c, "top", "HostConfig.NanoCpus")
-	c.Assert(out, checker.Equals, "8e+08", check.Commentf("updating the Nano CPUs failed"))
+	c.Assert(out, checker.Equals, "800000000", check.Commentf("updating the Nano CPUs failed"))
 	out = inspectField(c, "top", "HostConfig.CpuQuota")
 	c.Assert(out, checker.Equals, "0", check.Commentf("CPU CFS quota should be 0"))
 	out = inspectField(c, "top", "HostConfig.CpuPeriod")


### PR DESCRIPTION
Fixes the following tests:

- DockerSuite.TestRmiContainerImageNotFound (caused by docker/cli#160)
- DockerSuite.TestRmiImageIDForceWithRunningContainersAndMultipleTags (caused by docker/cli#160)
- DockerSuite.TestRunWithNanoCPUs (caused by docker/cli#202)
- DockerSuite.TestUpdateWithNanoCPUs (caused by docker/cli#202)
- DockerSwarmSuite.TestServiceLogs (caused by docker/cli#121)
- DockerSwarmSuite.TestSwarmNetworkPluginV2 (caused by docker/cli#121)
- DockerSwarmSuite.TestSwarmServicePsMultipleServiceIDs (caused by docker/cli#72)

Punting on:
- DockerSuite.TestRunAttachDetachFromInvalidFlag (investigating in docker/cli#380)

Test verified by compiling cli from docker-ce 17.07 branch and using that when running test-integration-cli test from engine component of docker-ce 17.07 branch, e.g.
```
$ make BIND_DIR=. \
  DOCKER_CLI_PATH=/path/to/cli/build/docker-linux-amd64 \
  TESTFLAGS='-check.f DockerSuite.TestRmiContainerImageNotFound' \
  test-integration-cli
PASS: docker_cli_rmi_test.go:227: DockerSuite.TestRmiContainerImageNotFound	2.680s
OK: 1 passed
```