### PR TITLE
[17.06] Fix error handling with not-exist errors on remove

### DIFF
--- a/components/engine/daemon/delete.go
+++ b/components/engine/daemon/delete.go
@@ -117,7 +117,7 @@ func (daemon *Daemon) cleanupContainer(container *container.Container, forceRemo
 	if container.RWLayer != nil {
 		metadata, err := daemon.layerStore.ReleaseRWLayer(container.RWLayer)
 		layer.LogReleaseMetadata(metadata)
-		if err != nil && err != layer.ErrMountDoesNotExist {
+		if err != nil && err != layer.ErrMountDoesNotExist && !os.IsNotExist(errors.Cause(err)) {
 			return errors.Wrapf(err, "driver %q failed to remove root filesystem for %s", daemon.GraphDriverName(), container.ID)
 		}
 	}


### PR DESCRIPTION
Backport moby/moby#33960 Fix error handling with not-exist errors on remove

Cherry-pick commit moby/moby@d42dbdd
```
$ git cherry-pick -s -x -Xsubtree=components/engine d42dbdd
```