### PR TITLE
[17.06] backport Skip inspect of built-in networks on stack deploy

### DIFF
--- a/components/cli/cli/command/network/inspect.go
+++ b/components/cli/cli/command/network/inspect.go
@@ -6,6 +6,7 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/inspect"
+	"github.com/docker/docker/api/types"
 	"github.com/spf13/cobra"
 )
 
@@ -40,7 +41,7 @@ func runInspect(dockerCli *command.DockerCli, opts inspectOptions) error {
 	ctx := context.Background()
 
 	getNetFunc := func(name string) (interface{}, []byte, error) {
-		return client.NetworkInspectWithRaw(ctx, name, opts.verbose)
+		return client.NetworkInspectWithRaw(ctx, name, types.NetworkInspectOptions{Verbose: opts.verbose})
 	}
 
 	return inspect.Inspect(dockerCli.Out(), opts.names, opts.format, getNetFunc)

--- a/components/cli/cli/command/network/remove.go
+++ b/components/cli/cli/command/network/remove.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/docker/api/types"
 	"github.com/spf13/cobra"
 )
 
@@ -33,7 +34,7 @@ func runRemove(dockerCli *command.DockerCli, networks []string) error {
 	status := 0
 
 	for _, name := range networks {
-		if nw, _, err := client.NetworkInspectWithRaw(ctx, name, false); err == nil &&
+		if nw, _, err := client.NetworkInspectWithRaw(ctx, name, types.NetworkInspectOptions{}); err == nil &&
 			nw.Ingress &&
 			!command.PromptForConfirmation(dockerCli.In(), dockerCli.Out(), ingressWarning) {
 			continue

--- a/components/cli/cli/command/service/inspect.go
+++ b/components/cli/cli/command/service/inspect.go
@@ -61,7 +61,7 @@ func runInspect(dockerCli *command.DockerCli, opts inspectOptions) error {
 	}
 
 	getNetwork := func(ref string) (interface{}, []byte, error) {
-		network, _, err := client.NetworkInspectWithRaw(ctx, ref, false)
+		network, _, err := client.NetworkInspectWithRaw(ctx, ref, types.NetworkInspectOptions{Scope: "swarm"})
 		if err == nil || !apiclient.IsErrNetworkNotFound(err) {
 			return network, nil, err
 		}

--- a/components/cli/cli/command/service/opts.go
+++ b/components/cli/cli/command/service/opts.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/docker/cli/opts"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
@@ -400,7 +401,7 @@ func convertNetworks(ctx context.Context, apiClient client.NetworkAPIClient, net
 	var netAttach []swarm.NetworkAttachmentConfig
 	for _, net := range networks.Value() {
 		networkIDOrName := net.Target
-		_, err := apiClient.NetworkInspect(ctx, networkIDOrName, false)
+		_, err := apiClient.NetworkInspect(ctx, networkIDOrName, types.NetworkInspectOptions{Scope: "swarm"})
 		if err != nil {
 			return nil, err
 		}

--- a/components/cli/cli/command/service/update.go
+++ b/components/cli/cli/command/service/update.go
@@ -1009,7 +1009,7 @@ func updateNetworks(ctx context.Context, apiClient client.NetworkAPIClient, flag
 	toRemove := buildToRemoveSet(flags, flagNetworkRemove)
 	idsToRemove := make(map[string]struct{})
 	for networkIDOrName := range toRemove {
-		network, err := apiClient.NetworkInspect(ctx, networkIDOrName, false)
+		network, err := apiClient.NetworkInspect(ctx, networkIDOrName, types.NetworkInspectOptions{Scope: "swarm"})
 		if err != nil {
 			return err
 		}

--- a/components/cli/cli/command/stack/deploy_composefile.go
+++ b/components/cli/cli/command/stack/deploy_composefile.go
@@ -174,7 +174,7 @@ func validateExternalNetworks(
 	externalNetworks []string,
 ) error {
 	for _, networkName := range externalNetworks {
-		network, err := client.NetworkInspect(ctx, networkName, false)
+		network, err := client.NetworkInspect(ctx, networkName, types.NetworkInspectOptions{})
 		switch {
 		case dockerclient.IsErrNotFound(err):
 			return errors.Errorf("network %q is declared as external, but could not be found. You need to create a swarm-scoped network before the stack is deployed", networkName)

--- a/components/cli/cli/command/stack/deploy_composefile.go
+++ b/components/cli/cli/command/stack/deploy_composefile.go
@@ -174,13 +174,18 @@ func validateExternalNetworks(
 	externalNetworks []string,
 ) error {
 	for _, networkName := range externalNetworks {
+		if !container.NetworkMode(networkName).IsUserDefined() {
+			// Networks that are not user defined always exist on all nodes as
+			// local-scoped networks, so there's no need to inspect them.
+			continue
+		}
 		network, err := client.NetworkInspect(ctx, networkName, types.NetworkInspectOptions{})
 		switch {
 		case dockerclient.IsErrNotFound(err):
 			return errors.Errorf("network %q is declared as external, but could not be found. You need to create a swarm-scoped network before the stack is deployed", networkName)
 		case err != nil:
 			return err
-		case container.NetworkMode(networkName).IsUserDefined() && network.Scope != "swarm":
+		case network.Scope != "swarm":
 			return errors.Errorf("network %q is declared as external, but it is not in the right scope: %q instead of \"swarm\"", networkName, network.Scope)
 		}
 	}

--- a/components/cli/cli/command/stack/deploy_composefile_test.go
+++ b/components/cli/cli/command/stack/deploy_composefile_test.go
@@ -70,7 +70,7 @@ func TestValidateExternalNetworks(t *testing.T) {
 
 	for _, testcase := range testcases {
 		fakeClient := &network.FakeClient{
-			NetworkInspectFunc: func(_ context.Context, _ string, _ bool) (types.NetworkResource, error) {
+			NetworkInspectFunc: func(_ context.Context, _ string, _ types.NetworkInspectOptions) (types.NetworkResource, error) {
 				return testcase.inspectResponse, testcase.inspectError
 			},
 		}

--- a/components/cli/cli/command/system/inspect.go
+++ b/components/cli/cli/command/system/inspect.go
@@ -68,7 +68,7 @@ func inspectImages(ctx context.Context, dockerCli *command.DockerCli) inspect.Ge
 
 func inspectNetwork(ctx context.Context, dockerCli *command.DockerCli) inspect.GetRefFunc {
 	return func(ref string) (interface{}, []byte, error) {
-		return dockerCli.Client().NetworkInspectWithRaw(ctx, ref, false)
+		return dockerCli.Client().NetworkInspectWithRaw(ctx, ref, types.NetworkInspectOptions{})
 	}
 }
 

--- a/components/cli/cli/internal/test/network/client.go
+++ b/components/cli/cli/internal/test/network/client.go
@@ -9,7 +9,7 @@ import (
 
 // FakeClient is a fake NetworkAPIClient
 type FakeClient struct {
-	NetworkInspectFunc func(ctx context.Context, networkID string, verbose bool) (types.NetworkResource, error)
+	NetworkInspectFunc func(ctx context.Context, networkID string, options types.NetworkInspectOptions) (types.NetworkResource, error)
 }
 
 // NetworkConnect fakes connecting to a network
@@ -28,15 +28,15 @@ func (c *FakeClient) NetworkDisconnect(ctx context.Context, networkID, container
 }
 
 // NetworkInspect fakes inspecting a network
-func (c *FakeClient) NetworkInspect(ctx context.Context, networkID string, verbose bool) (types.NetworkResource, error) {
+func (c *FakeClient) NetworkInspect(ctx context.Context, networkID string, options types.NetworkInspectOptions) (types.NetworkResource, error) {
 	if c.NetworkInspectFunc != nil {
-		return c.NetworkInspectFunc(ctx, networkID, verbose)
+		return c.NetworkInspectFunc(ctx, networkID, options)
 	}
 	return types.NetworkResource{}, nil
 }
 
 // NetworkInspectWithRaw fakes inspecting a network with a raw response
-func (c *FakeClient) NetworkInspectWithRaw(ctx context.Context, networkID string, verbose bool) (types.NetworkResource, []byte, error) {
+func (c *FakeClient) NetworkInspectWithRaw(ctx context.Context, networkID string, options types.NetworkInspectOptions) (types.NetworkResource, []byte, error) {
 	return types.NetworkResource{}, nil, nil
 }
 


### PR DESCRIPTION
To backport fix:
* docker/cli/pull/362 Skip inspect of built-in networks on stack deploy

Attempted to cherry-pick the only commit of that PR, docker/cli@7f53c99, and had a conflict. Chose to resolve it by bringing in one more older commit docker/cli@657457e from PR docker/cli/pull/184

Cherry pick command for docker/cli@657457e (to prevent conflict) and docker/cli@7f53c99 (to bring in originally intended fix):
```
$ git cherry-pick -s -x -Xsubtree=components/cli 657457e 7f53c99
```
This then resulted in no conflicts.

cc @alexmavr @mavenugo @dnephin @thaJeztah may want to double check if the extra commit is ok to bring in to avoid the cherry-pick conflict