### PR TITLE
[17.06] Changing get network request to return predefined network in swarm

### DIFF
--- a/components/engine/api/server/router/network/network_routes.go
+++ b/components/engine/api/server/router/network/network_routes.go
@@ -127,6 +127,15 @@ func (n *networkRouter) getNetwork(ctx context.Context, w http.ResponseWriter, r
 		}
 	}
 
+	nwk, err := n.cluster.GetNetwork(term)
+	if err == nil {
+		// If the get network is passed with a specific network ID / partial network ID
+		// return the network.
+		if strings.HasPrefix(nwk.ID, term) {
+			return httputils.WriteJSON(w, http.StatusOK, nwk)
+		}
+	}
+
 	nr, _ := n.cluster.GetNetworks()
 	for _, network := range nr {
 		if network.ID == term {


### PR DESCRIPTION
Starting 17.06 swarm service create supports service creates with predefined
networks like host and bridge. Due to the nature of the feature, swarm manager
has a swarm scope predefined networks in addition to local scoped
predefined networks on all nodes. However network inspects for swarm scoped
predefined networks was not possible. The fix adds support for network inspect
for swarm scoped predefined networks.

Signed-off-by: Abhinandan Prativadi <abhi@docker.com>

Since the cherry pick of moby/moby#34302 is not possible due to function difference. Raising this PR in docker-ce
