### PR TITLE
[17.06] Error if "until" filter is combined with "--volumes" on system prune

### DIFF
--- a/components/cli/cli/command/system/prune.go
+++ b/components/cli/cli/command/system/prune.go
@@ -52,6 +52,10 @@ const confirmationTemplate = `WARNING! This will remove:
 Are you sure you want to continue?`
 
 func runPrune(dockerCli command.Cli, options pruneOptions) error {
+	// TODO version this once "until" filter is supported for volumes
+	if options.pruneVolumes && options.filter.Value().Include("until") {
+		return fmt.Errorf(`ERROR: The "until" filter is not supported with "--volumes"`)
+	}
 	if !options.force && !command.PromptForConfirmation(dockerCli.In(), dockerCli.Out(), confirmationMessage(options)) {
 		return nil
 	}


### PR DESCRIPTION
cherry picked from commit https://github.com/docker/cli/commit/3c095dc546e9c90afcfb1ca1695b408d813b4306 (https://github.com/docker/cli/pull/311)

conflicted with https://github.com/docker/docker-ce/commit/f7a9f9fb67187e89564037c8dbd25eeb6580b242 (https://github.com/docker/docker-ce/pull/109)

The "until" filter is supported by all object types, except for
volumes.

Before this patch, the "until" filter would attempted to be used for the volume
prune endpoint, resulting in an error being returned by the daemon, and
further prune endpoints (networks, images) to be skipped.

    $ docker system prune --filter until=24h --filter label=label.foo=bar

    WARNING! This will remove:
            - all stopped containers
            - all volumes not used by at least one container
            - all networks not used by at least one container
            - all dangling images
    Are you sure you want to continue? [y/N] y
    Error response from daemon: Invalid filter 'until'

    Calling POST /v1.30/containers/prune?filters=%7B%22label%22%3A%7B%22label.foo%3D%3Dbar%22%3Atrue%7D%2C%22until%22%3A%7B%2224h%22%3Atrue%7D%7D
    Calling POST /v1.30/volumes/prune?filters=%7B%22label%22%3A%7B%22label.foo%3D%3Dbar%22%3Atrue%7D%2C%22until%22%3A%7B%2224h%22%3Atrue%7D%7D
    Handler for POST /v1.30/volumes/prune returned error: Invalid filter 'until'
    Error response from daemon: Invalid filter 'until'

With this patch, an error is produced instead, preventing "partial" prune.

    $ docker system prune --filter until=24h --filter label=foo==bar --volumes
    ERROR: The "until" filter is not supported with "--volumes"

Note that `docker volume prune` does not have this problem, and produces an
error if the `until` filter is used;

    $ docker volume prune --filter until=24h

    WARNING! This will remove all volumes not used by at least one container.
    Are you sure you want to continue? [y/N] y
    Error response from daemon: Invalid filter 'until'
