### PR TITLE
[17.06] backport Skip inspect of built-in networks on stack deploy

### DIFF
--- a/components/cli/cli/command/stack/deploy_composefile.go
+++ b/components/cli/cli/command/stack/deploy_composefile.go
@@ -174,13 +174,18 @@ func validateExternalNetworks(
 	externalNetworks []string,
 ) error {
 	for _, networkName := range externalNetworks {
+		if !container.NetworkMode(networkName).IsUserDefined() {
+			// Networks that are not user defined always exist on all nodes as
+			// local-scoped networks, so there's no need to inspect them.
+			continue
+		}
 		network, err := client.NetworkInspect(ctx, networkName, false)
 		switch {
 		case dockerclient.IsErrNotFound(err):
 			return errors.Errorf("network %q is declared as external, but could not be found. You need to create a swarm-scoped network before the stack is deployed", networkName)
 		case err != nil:
 			return err
-		case container.NetworkMode(networkName).IsUserDefined() && network.Scope != "swarm":
+		case network.Scope != "swarm":
 			return errors.Errorf("network %q is declared as external, but it is not in the right scope: %q instead of \"swarm\"", networkName, network.Scope)
 		}
 	}

--- a/components/cli/cli/command/stack/deploy_composefile_test.go
+++ b/components/cli/cli/command/stack/deploy_composefile_test.go
@@ -42,6 +42,8 @@ func (n notFound) NotFound() bool {
 
 func TestValidateExternalNetworks(t *testing.T) {
 	var testcases = []struct {
+		inspected       bool
+		noInspect       bool
 		inspectResponse types.NetworkResource
 		inspectError    error
 		expectedMsg     string
@@ -56,7 +58,8 @@ func TestValidateExternalNetworks(t *testing.T) {
 			expectedMsg:  "Unexpected",
 		},
 		{
-			network: "host",
+			noInspect: true,
+			network:   "host",
 		},
 		{
 			network:     "user",
@@ -71,11 +74,15 @@ func TestValidateExternalNetworks(t *testing.T) {
 	for _, testcase := range testcases {
 		fakeClient := &network.FakeClient{
 			NetworkInspectFunc: func(_ context.Context, _ string, _ bool) (types.NetworkResource, error) {
+				testcase.inspected = true
 				return testcase.inspectResponse, testcase.inspectError
 			},
 		}
 		networks := []string{testcase.network}
 		err := validateExternalNetworks(context.Background(), fakeClient, networks)
+		if testcase.noInspect && testcase.inspected {
+			assert.Fail(t, "expected no network inspect operation but one occurent")
+		}
 		if testcase.expectedMsg == "" {
 			assert.NoError(t, err)
 		} else {


### PR DESCRIPTION
To backport fix:

- docker/cli#362 Skip inspect of built-in networks on stack deploy

Cherry pick conflict was resolved by retaining the signature of the `NetworkInspect` operation as `func(context.Context, string, bool) (types.NetworkResource, error)`

This PR was behaviorally validated via `make static` and using the resulting binaries to deploy a compose file with an external network named `host`.

cc @dnephin @vdemeester @thaJeztah 

Operations followed:
```
$ git clone git@github.com:docker/docker-ce # fresh clone
$ cd docker-ce # enter the working dir
$ git checkout 17.06 # checkout the branch
$ git fetch git@github.com:docker/cli master:cli # get the git commits from upstream cli
$ git cherry-pick -s -x -Xsubtree=components/cli 7f53c99 # pick just the one commit
```

Supercedes https://github.com/docker/docker-ce/pull/146