### PR TITLE
[17.06] backport fix for lock container while connecting to a new network

### DIFF
--- a/components/engine/daemon/container_operations.go
+++ b/components/engine/daemon/container_operations.go
@@ -980,6 +980,9 @@ func (daemon *Daemon) ConnectToNetwork(container *container.Container, idOrName 
 	if endpointConfig == nil {
 		endpointConfig = &networktypes.EndpointSettings{}
 	}
+	container.Lock()
+	defer container.Unlock()
+
 	if !container.Running {
 		if container.RemovalInProgress || container.Dead {
 			return errRemovalContainer(container.ID)
@@ -1002,7 +1005,7 @@ func (daemon *Daemon) ConnectToNetwork(container *container.Container, idOrName 
 			return err
 		}
 	}
-	if err := container.ToDiskLocking(); err != nil {
+	if err := container.ToDisk(); err != nil {
 		return fmt.Errorf("Error saving container to disk: %v", err)
 	}
 	return nil
@@ -1011,6 +1014,9 @@ func (daemon *Daemon) ConnectToNetwork(container *container.Container, idOrName 
 // DisconnectFromNetwork disconnects container from network n.
 func (daemon *Daemon) DisconnectFromNetwork(container *container.Container, networkName string, force bool) error {
 	n, err := daemon.FindNetwork(networkName)
+	container.Lock()
+	defer container.Unlock()
+
 	if !container.Running || (err != nil && force) {
 		if container.RemovalInProgress || container.Dead {
 			return errRemovalContainer(container.ID)
@@ -1038,7 +1044,7 @@ func (daemon *Daemon) DisconnectFromNetwork(container *container.Container, netw
 		return err
 	}
 
-	if err := container.ToDiskLocking(); err != nil {
+	if err := container.ToDisk(); err != nil {
 		return fmt.Errorf("Error saving container to disk: %v", err)
 	}
 


### PR DESCRIPTION
Backport fix:
* moby/moby/pull/33456 Lock container while connecting to a new network.

To address issue:
`ConnectToNetwork` is modfying the container but is not locking theobject.

This was backported to 17.03 but did not make it to 17.06.