### PR TITLE
[17.06] Cherry pick static file hashing commits

### DIFF
--- a/components/packaging/static/Makefile
+++ b/components/packaging/static/Makefile
@@ -5,7 +5,7 @@ CLI_DIR:=$(CURDIR)/../../cli
 ENGINE_VER=$(shell cat $(ENGINE_DIR)/VERSION)
 VERSION=$(shell cat $(ENGINE_DIR)/VERSION)
 CHOWN=docker run --rm -v $(CURDIR):/v -w /v $(ALPINE_IMG) chown
-HASH_CMD=docker run -v $(CURDIR):/sum -it -w /sum debian:jessie bash hash_files
+HASH_CMD=docker run -v $(CURDIR):/sum -w /sum debian:jessie bash hash_files
 DIR_TO_HASH:=build/linux
 
 .PHONY: help clean static static-linux cross-mac cross-win cross-arm static-cli static-engine cross-all-cli cross-win-engine hash_files

--- a/components/packaging/static/Makefile
+++ b/components/packaging/static/Makefile
@@ -5,7 +5,7 @@ CLI_DIR:=$(CURDIR)/../../cli
 ENGINE_VER=$(shell cat $(ENGINE_DIR)/VERSION)
 VERSION=$(shell cat $(ENGINE_DIR)/VERSION)
 CHOWN=docker run --rm -v $(CURDIR):/v -w /v $(ALPINE_IMG) chown
-HASH_CMD=docker run -v $(CURDIR):/sum -w /sum debian:jessie bash hash_files
+HASH_CMD=docker run -v $(CURDIR):/sum -it -w /sum debian:jessie bash hash_files
 DIR_TO_HASH:=build/linux
 
 .PHONY: help clean static static-linux cross-mac cross-win cross-arm static-cli static-engine cross-all-cli cross-win-engine hash_files
@@ -26,7 +26,10 @@ static-linux: static-cli static-engine ## create tgz with linux x86_64 client an
 		cp $(ENGINE_DIR)/bundles/$(ENGINE_VER)/binary-daemon/$$f build/linux/docker; \
 	done
 	tar -C build/linux -c -z -f build/linux/docker-$(VERSION).tgz docker
-	$(HASH_CMD) build/linux
+
+hash_files:
+	@echo "Hashing directory $(DIR_TO_HASH)"
+	$(HASH_CMD) "$(DIR_TO_HASH)"
 
 hash_files:
 	@echo "Hashing directory $(DIR_TO_HASH)"
@@ -36,7 +39,6 @@ cross-mac: cross-all-cli ## create tgz with darwin x86_64 client only
 	mkdir -p build/mac/docker
 	cp $(CLI_DIR)/build/docker-darwin-amd64 build/mac/docker/docker
 	tar -C build/mac -c -z -f build/mac/docker-$(VERSION).tgz docker
-	$(HASH_CMD) build/mac
 
 cross-win: cross-all-cli cross-win-engine ## create zip file with windows x86_64 client and server
 	mkdir -p build/win/docker
@@ -44,13 +46,11 @@ cross-win: cross-all-cli cross-win-engine ## create zip file with windows x86_64
 	cp $(ENGINE_DIR)/bundles/$(ENGINE_VER)/cross/windows/amd64/dockerd-$(ENGINE_VER).exe build/win/docker/dockerd.exe
 	docker run --rm -v $(CURDIR)/build/win:/v -w /v $(ALPINE_IMG) sh -c 'apk update&&apk add zip&&zip -r docker-$(VERSION).zip docker'
 	$(CHOWN) -R $(shell id -u):$(shell id -g) build
-	$(HASH_CMD) bash hash_files build/win
 
 cross-arm: cross-all-cli ## create tgz with linux armhf client only
 	mkdir -p build/arm/docker
 	cp $(CLI_DIR)/build/docker-linux-arm build/arm/docker/docker
 	tar -C build/arm -c -z -f build/arm/docker-$(VERSION).tgz docker
-	$(HASH_CMD) build/arm
 
 static-cli:
 	$(MAKE) -C $(CLI_DIR) -f docker.Makefile VERSION=$(VERSION) build


### PR DESCRIPTION
Not entirely sure how this didn't make it into 17.06.0-ce but these commits split the file hashing target for static files into separate target.

The `cross-win` target fails without these changes

cc @andrewhsu 