### PR TITLE
[17.06] Move the hashing of files to its own target

### DIFF
--- a/components/packaging/static/Makefile
+++ b/components/packaging/static/Makefile
@@ -26,7 +26,6 @@ static-linux: static-cli static-engine ## create tgz with linux x86_64 client an
 		cp $(ENGINE_DIR)/bundles/$(ENGINE_VER)/binary-daemon/$$f build/linux/docker; \
 	done
 	tar -C build/linux -c -z -f build/linux/docker-$(VERSION).tgz docker
-	$(HASH_CMD) build/linux
 
 hash_files:
 	@echo "Hashing directory $(DIR_TO_HASH)"
@@ -36,7 +35,6 @@ cross-mac: cross-all-cli ## create tgz with darwin x86_64 client only
 	mkdir -p build/mac/docker
 	cp $(CLI_DIR)/build/docker-darwin-amd64 build/mac/docker/docker
 	tar -C build/mac -c -z -f build/mac/docker-$(VERSION).tgz docker
-	$(HASH_CMD) build/mac
 
 cross-win: cross-all-cli cross-win-engine ## create zip file with windows x86_64 client and server
 	mkdir -p build/win/docker
@@ -44,13 +42,11 @@ cross-win: cross-all-cli cross-win-engine ## create zip file with windows x86_64
 	cp $(ENGINE_DIR)/bundles/$(ENGINE_VER)/cross/windows/amd64/dockerd-$(ENGINE_VER).exe build/win/docker/dockerd.exe
 	docker run --rm -v $(CURDIR)/build/win:/v -w /v $(ALPINE_IMG) sh -c 'apk update&&apk add zip&&zip -r docker-$(VERSION).zip docker'
 	$(CHOWN) -R $(shell id -u):$(shell id -g) build
-	$(HASH_CMD) bash hash_files build/win
 
 cross-arm: cross-all-cli ## create tgz with linux armhf client only
 	mkdir -p build/arm/docker
 	cp $(CLI_DIR)/build/docker-linux-arm build/arm/docker/docker
 	tar -C build/arm -c -z -f build/arm/docker-$(VERSION).tgz docker
-	$(HASH_CMD) build/arm
 
 static-cli:
 	$(MAKE) -C $(CLI_DIR) -f docker.Makefile VERSION=$(VERSION) build


### PR DESCRIPTION
Don't really know how this commit didn't fully get in but this basically removes the $(HASH_CMD) from the basic static targets.

Without this the `cross-win` target for `components/packaging/static/Makefile` will fail.

Cherry-picked from: https://github.com/docker/docker-ce-packaging/pull/1

```
git cherry-pick -x -s -Xsubtree="components/packaging" 533a843393bd7c3674074ec9af73c8e666fc7484
```

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>
(cherry picked from commit 533a843393bd7c3674074ec9af73c8e666fc7484)
Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>