### PR TITLE
[17.06] backport Make plugins dir private

### DIFF
--- a/components/engine/plugin/manager.go
+++ b/components/engine/plugin/manager.go
@@ -102,6 +102,11 @@ func NewManager(config ManagerConfig) (*Manager, error) {
 	if err := os.MkdirAll(manager.tmpDir(), 0700); err != nil {
 		return nil, errors.Wrapf(err, "failed to mkdir %v", manager.tmpDir())
 	}
+
+	if err := setupRoot(manager.config.Root); err != nil {
+		return nil, err
+	}
+
 	var err error
 	manager.containerdClient, err = config.Executor.Client(manager) // todo: move to another struct
 	if err != nil {

--- a/components/engine/plugin/manager_linux.go
+++ b/components/engine/plugin/manager_linux.go
@@ -161,6 +161,13 @@ func shutdownPlugin(p *v2.Plugin, c *controller, containerdClient libcontainerd.
 	}
 }
 
+func setupRoot(root string) error {
+	if err := mount.MakePrivate(root); err != nil {
+		return errors.Wrap(err, "error setting plugin manager root to private")
+	}
+	return nil
+}
+
 func (pm *Manager) disable(p *v2.Plugin, c *controller) error {
 	if !p.IsEnabled() {
 		return fmt.Errorf("plugin %s is already disabled", p.Name())
@@ -189,6 +196,7 @@ func (pm *Manager) Shutdown() {
 			shutdownPlugin(p, c, pm.containerdClient)
 		}
 	}
+	mount.Unmount(pm.config.Root)
 }
 
 func (pm *Manager) upgradePlugin(p *v2.Plugin, configDigest digest.Digest, blobsums []digest.Digest, tmpRootFSDir string, privileges *types.PluginPrivileges) (err error) {

--- a/components/engine/plugin/manager_solaris.go
+++ b/components/engine/plugin/manager_solaris.go
@@ -26,3 +26,5 @@ func (pm *Manager) restore(p *v2.Plugin) error {
 // Shutdown plugins
 func (pm *Manager) Shutdown() {
 }
+
+func setupRoot(root string) error { return nil }

--- a/components/engine/plugin/manager_windows.go
+++ b/components/engine/plugin/manager_windows.go
@@ -28,3 +28,5 @@ func (pm *Manager) restore(p *v2.Plugin) error {
 // Shutdown plugins
 func (pm *Manager) Shutdown() {
 }
+
+func setupRoot(root string) error { return nil }


### PR DESCRIPTION
backport:
* moby/moby/pull/34374 Make plugins dir private.

with cherry pick moby/moby@0c2821d
```
$ git cherry-pick -s -x -Xsubtree=components/engine 0c2821d
```