### PR TITLE
[17.06] backport "Enable TCP Keep-Alive in Docker client"

### DIFF
--- a/components/cli/cli/command/cli.go
+++ b/components/cli/cli/command/cli.go
@@ -3,9 +3,11 @@ package command
 import (
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"runtime"
+	"time"
 
 	"github.com/docker/cli/cli"
 	cliconfig "github.com/docker/cli/cli/config"
@@ -285,6 +287,10 @@ func newHTTPClient(host string, tlsOptions *tlsconfig.Options) (*http.Client, er
 	}
 	tr := &http.Transport{
 		TLSClientConfig: config,
+		DialContext: (&net.Dialer{
+			KeepAlive: 30 * time.Second,
+			Timeout:   30 * time.Second,
+		}).DialContext,
 	}
 	proto, addr, _, err := client.ParseHost(host)
 	if err != nil {


### PR DESCRIPTION
cherry-picked from https://github.com/docker/cli/commit/2831a04cbad65e11081b0cd189599767fce3646a (https://github.com/docker/cli/pull/415/) - no conflicts

Some network environments may have NATs, proxies, or gateways which
kill idle connections. There are many Docker API operations which may
be idle for long periods of time (such as ContainerWait and ContainerAttach)
and may result in unexpected connection closures or hangs if TCP keepalives
are not used.

This patch updates the default HTTP transport used by the Docker client
package to enable TCP Keep-Alive with a keep-alive interval of 30 seconds.
It also sets a connect timeout of 30 seconds.

ping @dhiltgen @dnephin @jlhawn PTAL