### PR TITLE
[17.07] backport Fix delete container

### DIFF
--- a/components/engine/container/view.go
+++ b/components/engine/container/view.go
@@ -168,9 +168,9 @@ func (db *memDB) Delete(c *Container) error {
 			txn.Delete(memdbNamesTable, nameAssociation{name: name})
 		}
 
-		if err := txn.Delete(memdbContainersTable, NewBaseContainer(c.ID, c.Root)); err != nil {
-			return err
-		}
+		// Ignore error - the container may not actually exist in the
+		// db, but we still need to clean up associated names.
+		txn.Delete(memdbContainersTable, NewBaseContainer(c.ID, c.Root))
 		return nil
 	})
 }

--- a/components/engine/container/view_test.go
+++ b/components/engine/container/view_test.go
@@ -150,4 +150,12 @@ func TestNames(t *testing.T) {
 
 	view = db.Snapshot()
 	assert.Equal(t, map[string][]string{"containerid1": {"name1", "name3", "name4"}, "containerid4": {"name2"}}, view.GetAllNames())
+
+	// Release containerid1's names with Delete even though no container exists
+	assert.NoError(t, db.Delete(&Container{ID: "containerid1"}))
+
+	// Reusing one of those names should work
+	assert.NoError(t, db.ReserveName("name1", "containerid4"))
+	view = db.Snapshot()
+	assert.Equal(t, map[string][]string{"containerid4": {"name1", "name2"}}, view.GetAllNames())
 }


### PR DESCRIPTION
backport:


* moby/moby#34274 Fix Delete on nonexistent container.

with cherry pick moby/moby@1d9546f

```
$ git cherry-pick -s -x -Xsubtree=components/engine  1d9546f
```