### PR TITLE
[17.07] backport Fixing issue with driver opt not passed to drivers

### DIFF
--- a/components/engine/container/container.go
+++ b/components/engine/container/container.go
@@ -745,6 +745,9 @@ func (container *Container) BuildCreateEndpointOptions(n libnetwork.Network, epC
 		for _, alias := range epConfig.Aliases {
 			createOptions = append(createOptions, libnetwork.CreateOptionMyAlias(alias))
 		}
+		for k, v := range epConfig.DriverOpts {
+			createOptions = append(createOptions, libnetwork.EndpointOptionGeneric(options.Generic{k: v}))
+		}
 	}
 
 	if container.NetworkSettings.Service != nil {
@@ -789,9 +792,6 @@ func (container *Container) BuildCreateEndpointOptions(n libnetwork.Network, epC
 			}
 
 			createOptions = append(createOptions, libnetwork.EndpointOptionGeneric(genericOption))
-		}
-		for k, v := range epConfig.DriverOpts {
-			createOptions = append(createOptions, libnetwork.EndpointOptionGeneric(options.Generic{k: v}))
 		}
 
 	}


### PR DESCRIPTION
backport:
* moby/moby/pull/34194 Fixing issue with driver opt not passed to drivers.

with cherry pick moby/moby@bcb55c6
```
$ git cherry-pick -s -x -Xsubtree=components/engine bcb55c6
```