### PR TITLE
[17.07] backport for Hide swarm plugins behind experimental flag

### DIFF
--- a/components/engine/api/swagger.yaml
+++ b/components/engine/api/swagger.yaml
@@ -1981,7 +1981,7 @@ definitions:
     properties:
       PluginSpec:
         type: "object"
-        description: "Invalid when specified with `ContainerSpec`."
+        description: "Invalid when specified with `ContainerSpec`. *(Experimental release only.)*"
         properties:
           Name:
             description: "The name or 'alias' to use for the plugin."

--- a/components/engine/daemon/cluster/executor/container/executor.go
+++ b/components/engine/daemon/cluster/executor/container/executor.go
@@ -183,13 +183,17 @@ func (e *executor) Controller(t *api.Task) (exec.Controller, error) {
 		}
 		switch runtimeKind {
 		case string(swarmtypes.RuntimePlugin):
+			info, _ := e.backend.SystemInfo()
+			if !info.ExperimentalBuild {
+				return ctlr, fmt.Errorf("runtime type %q only supported in experimental", swarmtypes.RuntimePlugin)
+			}
 			c, err := plugin.NewController(e.pluginBackend, t)
 			if err != nil {
 				return ctlr, err
 			}
 			ctlr = c
 		default:
-			return ctlr, fmt.Errorf("unsupported runtime type: %q", r.Generic.Kind)
+			return ctlr, fmt.Errorf("unsupported runtime type: %q", runtimeKind)
 		}
 	case *api.TaskSpec_Container:
 		c, err := newController(e.backend, t, dependencyGetter)

--- a/components/engine/daemon/cluster/services.go
+++ b/components/engine/daemon/cluster/services.go
@@ -139,9 +139,16 @@ func (c *Cluster) CreateService(s types.ServiceSpec, encodedAuth string, queryRe
 		case *swarmapi.TaskSpec_Generic:
 			switch serviceSpec.Task.GetGeneric().Kind {
 			case string(types.RuntimePlugin):
+				info, _ := c.config.Backend.SystemInfo()
+				if !info.ExperimentalBuild {
+					return fmt.Errorf("runtime type %q only supported in experimental", types.RuntimePlugin)
+				}
 				if s.TaskTemplate.PluginSpec == nil {
 					return errors.New("plugin spec must be set")
 				}
+
+			default:
+				return fmt.Errorf("unsupported runtime type: %q", serviceSpec.Task.GetGeneric().Kind)
 			}
 
 			r, err := state.controlClient.CreateService(ctx, &swarmapi.CreateServiceRequest{Spec: &serviceSpec})

--- a/components/engine/integration-cli/docker_api_swarm_service_test.go
+++ b/components/engine/integration-cli/docker_api_swarm_service_test.go
@@ -603,7 +603,8 @@ func (s *DockerSwarmSuite) TestAPISwarmServicesStateReporting(c *check.C) {
 
 // Test plugins deployed via swarm services
 func (s *DockerSwarmSuite) TestAPISwarmServicesPlugin(c *check.C) {
-	testRequires(c, DaemonIsLinux, IsAmd64)
+	testRequires(c, ExperimentalDaemon, DaemonIsLinux, IsAmd64)
+
 	reg := setupRegistry(c, false, "", "")
 	defer reg.Close()
 


### PR DESCRIPTION
backport:
* moby/moby/pull/34455 Hide swarm plugins behind experimental flag.

with cherry pick moby/moby@4930020
```
$ git cherry-pick -s -x -Xsubtree=components/engine 4930020
```