### PR TITLE
[17.07] fix TestLogsFollowGoroutinesWithStdout in arm64

### DIFF
--- a/components/engine/vendor.conf
+++ b/components/engine/vendor.conf
@@ -83,7 +83,7 @@ github.com/philhofer/fwd 98c11a7a6ec829d672b03833c3d69a7fae1ca972
 github.com/tinylib/msgp 75ee40d2601edf122ef667e2a07d600d4c44490c
 
 # fsnotify
-github.com/fsnotify/fsnotify v1.2.11
+github.com/fsnotify/fsnotify v1.4.2
 
 # awslogs deps
 github.com/aws/aws-sdk-go v1.4.22

--- a/components/engine/vendor/github.com/fsnotify/fsnotify/README.md
+++ b/components/engine/vendor/github.com/fsnotify/fsnotify/README.md
@@ -1,8 +1,12 @@
 # File system notifications for Go
 
-[![GoDoc](https://godoc.org/github.com/fsnotify/fsnotify?status.svg)](https://godoc.org/github.com/fsnotify/fsnotify) [![Go Report Card](https://goreportcard.com/badge/github.com/fsnotify/fsnotify)](https://goreportcard.com/report/github.com/fsnotify/fsnotify) [![Coverage](http://gocover.io/_badge/github.com/fsnotify/fsnotify)](http://gocover.io/github.com/fsnotify/fsnotify) 
+[![GoDoc](https://godoc.org/github.com/fsnotify/fsnotify?status.svg)](https://godoc.org/github.com/fsnotify/fsnotify) [![Go Report Card](https://goreportcard.com/badge/github.com/fsnotify/fsnotify)](https://goreportcard.com/report/github.com/fsnotify/fsnotify)
 
-Go 1.3+ required.
+fsnotify utilizes [golang.org/x/sys](https://godoc.org/golang.org/x/sys) rather than `syscall` from the standard library. Ensure you have the latest version installed by running:
+
+```console
+go get -u golang.org/x/sys/...
+```
 
 Cross platform: Windows, Linux, BSD and OS X.
 
@@ -27,7 +31,7 @@ fsnotify is a fork of [howeyc/fsnotify](https://godoc.org/github.com/howeyc/fsno
 
 All [releases](https://github.com/fsnotify/fsnotify/releases) are tagged based on [Semantic Versioning](http://semver.org/). Further API changes are [planned](https://github.com/fsnotify/fsnotify/milestones), and will be tagged with a new major revision number.
 
-Go 1.6 supports dependencies located in the `vendor/` folder. Unless you are creating a library, it is recommended that you copy fsnotify into `vendor/github.com/fsnotify/fsnotify` within your project.
+Go 1.6 supports dependencies located in the `vendor/` folder. Unless you are creating a library, it is recommended that you copy fsnotify into `vendor/github.com/fsnotify/fsnotify` within your project, and likewise for `golang.org/x/sys`.
 
 ## Contributing
 

--- a/components/engine/vendor/github.com/fsnotify/fsnotify/fsnotify.go
+++ b/components/engine/vendor/github.com/fsnotify/fsnotify/fsnotify.go
@@ -30,33 +30,33 @@ const (
 	Chmod
 )
 
-// String returns a string representation of the event in the form
-// "file: REMOVE|WRITE|..."
-func (e Event) String() string {
+func (op Op) String() string {
 	// Use a buffer for efficient string concatenation
 	var buffer bytes.Buffer
 
-	if e.Op&Create == Create {
+	if op&Create == Create {
 		buffer.WriteString("|CREATE")
 	}
-	if e.Op&Remove == Remove {
+	if op&Remove == Remove {
 		buffer.WriteString("|REMOVE")
 	}
-	if e.Op&Write == Write {
+	if op&Write == Write {
 		buffer.WriteString("|WRITE")
 	}
-	if e.Op&Rename == Rename {
+	if op&Rename == Rename {
 		buffer.WriteString("|RENAME")
 	}
-	if e.Op&Chmod == Chmod {
+	if op&Chmod == Chmod {
 		buffer.WriteString("|CHMOD")
 	}
-
-	// If buffer remains empty, return no event names
 	if buffer.Len() == 0 {
-		return fmt.Sprintf("%q: ", e.Name)
+		return ""
 	}
+	return buffer.String()[1:] // Strip leading pipe
+}
 
-	// Return a list of event names, with leading pipe character stripped
-	return fmt.Sprintf("%q: %s", e.Name, buffer.String()[1:])
+// String returns a string representation of the event in the form
+// "file: REMOVE|WRITE|..."
+func (e Event) String() string {
+	return fmt.Sprintf("%q: %s", e.Name, e.Op.String())
 }

--- a/components/engine/vendor/github.com/fsnotify/fsnotify/inotify.go
+++ b/components/engine/vendor/github.com/fsnotify/fsnotify/inotify.go
@@ -14,8 +14,9 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/unix"
 )
 
 // Watcher watches a set of files, delivering events to a channel.
@@ -35,14 +36,14 @@ type Watcher struct {
 // NewWatcher establishes a new watcher with the underlying OS and begins waiting for events.
 func NewWatcher() (*Watcher, error) {
 	// Create inotify fd
-	fd, errno := syscall.InotifyInit()
+	fd, errno := unix.InotifyInit1(unix.IN_CLOEXEC)
 	if fd == -1 {
 		return nil, errno
 	}
 	// Create epoll
 	poller, err := newFdPoller(fd)
 	if err != nil {
-		syscall.Close(fd)
+		unix.Close(fd)
 		return nil, err
 	}
 	w := &Watcher{
@@ -95,9 +96,9 @@ func (w *Watcher) Add(name string) error {
 		return errors.New("inotify instance already closed")
 	}
 
-	const agnosticEvents = syscall.IN_MOVED_TO | syscall.IN_MOVED_FROM |
-		syscall.IN_CREATE | syscall.IN_ATTRIB | syscall.IN_MODIFY |
-		syscall.IN_MOVE_SELF | syscall.IN_DELETE | syscall.IN_DELETE_SELF
+	const agnosticEvents = unix.IN_MOVED_TO | unix.IN_MOVED_FROM |
+		unix.IN_CREATE | unix.IN_ATTRIB | unix.IN_MODIFY |
+		unix.IN_MOVE_SELF | unix.IN_DELETE | unix.IN_DELETE_SELF
 
 	var flags uint32 = agnosticEvents
 
@@ -106,9 +107,9 @@ func (w *Watcher) Add(name string) error {
 	w.mu.Unlock()
 	if found {
 		watchEntry.flags |= flags
-		flags |= syscall.IN_MASK_ADD
+		flags |= unix.IN_MASK_ADD
 	}
-	wd, errno := syscall.InotifyAddWatch(w.fd, name, flags)
+	wd, errno := unix.InotifyAddWatch(w.fd, name, flags)
 	if wd == -1 {
 		return errno
 	}
@@ -140,7 +141,7 @@ func (w *Watcher) Remove(name string) error {
 	// by calling inotify_rm_watch() below. e.g. readEvents() goroutine receives IN_IGNORE
 	// so that EINVAL means that the wd is being rm_watch()ed or its file removed
 	// by another thread and we have not received IN_IGNORE event.
-	success, errno := syscall.InotifyRmWatch(w.fd, watch.wd)
+	success, errno := unix.InotifyRmWatch(w.fd, watch.wd)
 	if success == -1 {
 		// TODO: Perhaps it's not helpful to return an error here in every case.
 		// the only two possible errors are:
@@ -170,16 +171,16 @@ type watch struct {
 // received events into Event objects and sends them via the Events channel
 func (w *Watcher) readEvents() {
 	var (
-		buf   [syscall.SizeofInotifyEvent * 4096]byte // Buffer for a maximum of 4096 raw events
-		n     int                                     // Number of bytes read with read()
-		errno error                                   // Syscall errno
-		ok    bool                                    // For poller.wait
+		buf   [unix.SizeofInotifyEvent * 4096]byte // Buffer for a maximum of 4096 raw events
+		n     int                                  // Number of bytes read with read()
+		errno error                                // Syscall errno
+		ok    bool                                 // For poller.wait
 	)
 
 	defer close(w.doneResp)
 	defer close(w.Errors)
 	defer close(w.Events)
-	defer syscall.Close(w.fd)
+	defer unix.Close(w.fd)
 	defer w.poller.close()
 
 	for {
@@ -202,20 +203,20 @@ func (w *Watcher) readEvents() {
 			continue
 		}
 
-		n, errno = syscall.Read(w.fd, buf[:])
+		n, errno = unix.Read(w.fd, buf[:])
 		// If a signal interrupted execution, see if we've been asked to close, and try again.
 		// http://man7.org/linux/man-pages/man7/signal.7.html :
 		// "Before Linux 3.8, reads from an inotify(7) file descriptor were not restartable"
-		if errno == syscall.EINTR {
+		if errno == unix.EINTR {
 			continue
 		}
 
-		// syscall.Read might have been woken up by Close. If so, we're done.
+		// unix.Read might have been woken up by Close. If so, we're done.
 		if w.isClosed() {
 			return
 		}
 
-		if n < syscall.SizeofInotifyEvent {
+		if n < unix.SizeofInotifyEvent {
 			var err error
 			if n == 0 {
 				// If EOF is received. This should really never happen.
@@ -238,9 +239,9 @@ func (w *Watcher) readEvents() {
 		var offset uint32
 		// We don't know how many events we just read into the buffer
 		// While the offset points to at least one whole event...
-		for offset <= uint32(n-syscall.SizeofInotifyEvent) {
+		for offset <= uint32(n-unix.SizeofInotifyEvent) {
 			// Point "raw" to the event in the buffer
-			raw := (*syscall.InotifyEvent)(unsafe.Pointer(&buf[offset]))
+			raw := (*unix.InotifyEvent)(unsafe.Pointer(&buf[offset]))
 
 			mask := uint32(raw.Mask)
 			nameLen := uint32(raw.Len)
@@ -253,7 +254,7 @@ func (w *Watcher) readEvents() {
 			w.mu.Unlock()
 			if nameLen > 0 {
 				// Point "bytes" at the first byte of the filename
-				bytes := (*[syscall.PathMax]byte)(unsafe.Pointer(&buf[offset+syscall.SizeofInotifyEvent]))
+				bytes := (*[unix.PathMax]byte)(unsafe.Pointer(&buf[offset+unix.SizeofInotifyEvent]))
 				// The filename is padded with NULL bytes. TrimRight() gets rid of those.
 				name += "/" + strings.TrimRight(string(bytes[0:nameLen]), "\000")
 			}
@@ -270,7 +271,7 @@ func (w *Watcher) readEvents() {
 			}
 
 			// Move to the next event in the buffer
-			offset += syscall.SizeofInotifyEvent + nameLen
+			offset += unix.SizeofInotifyEvent + nameLen
 		}
 	}
 }
@@ -280,7 +281,7 @@ func (w *Watcher) readEvents() {
 // against files that do not exist.
 func (e *Event) ignoreLinux(w *Watcher, wd int32, mask uint32) bool {
 	// Ignore anything the inotify API says to ignore
-	if mask&syscall.IN_IGNORED == syscall.IN_IGNORED {
+	if mask&unix.IN_IGNORED == unix.IN_IGNORED {
 		w.mu.Lock()
 		defer w.mu.Unlock()
 		name := w.paths[int(wd)]
@@ -305,19 +306,19 @@ func (e *Event) ignoreLinux(w *Watcher, wd int32, mask uint32) bool {
 // newEvent returns an platform-independent Event based on an inotify mask.
 func newEvent(name string, mask uint32) Event {
 	e := Event{Name: name}
-	if mask&syscall.IN_CREATE == syscall.IN_CREATE || mask&syscall.IN_MOVED_TO == syscall.IN_MOVED_TO {
+	if mask&unix.IN_CREATE == unix.IN_CREATE || mask&unix.IN_MOVED_TO == unix.IN_MOVED_TO {
 		e.Op |= Create
 	}
-	if mask&syscall.IN_DELETE_SELF == syscall.IN_DELETE_SELF || mask&syscall.IN_DELETE == syscall.IN_DELETE {
+	if mask&unix.IN_DELETE_SELF == unix.IN_DELETE_SELF || mask&unix.IN_DELETE == unix.IN_DELETE {
 		e.Op |= Remove
 	}
-	if mask&syscall.IN_MODIFY == syscall.IN_MODIFY {
+	if mask&unix.IN_MODIFY == unix.IN_MODIFY {
 		e.Op |= Write
 	}
-	if mask&syscall.IN_MOVE_SELF == syscall.IN_MOVE_SELF || mask&syscall.IN_MOVED_FROM == syscall.IN_MOVED_FROM {
+	if mask&unix.IN_MOVE_SELF == unix.IN_MOVE_SELF || mask&unix.IN_MOVED_FROM == unix.IN_MOVED_FROM {
 		e.Op |= Rename
 	}
-	if mask&syscall.IN_ATTRIB == syscall.IN_ATTRIB {
+	if mask&unix.IN_ATTRIB == unix.IN_ATTRIB {
 		e.Op |= Chmod
 	}
 	return e

--- a/components/engine/vendor/github.com/fsnotify/fsnotify/kqueue.go
+++ b/components/engine/vendor/github.com/fsnotify/fsnotify/kqueue.go
@@ -13,8 +13,9 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"syscall"
 	"time"
+
+	"golang.org/x/sys/unix"
 )
 
 // Watcher watches a set of files, delivering events to a channel.
@@ -113,12 +114,12 @@ func (w *Watcher) Remove(name string) error {
 		return fmt.Errorf("can't remove non-existent kevent watch for: %s", name)
 	}
 
-	const registerRemove = syscall.EV_DELETE
+	const registerRemove = unix.EV_DELETE
 	if err := register(w.kq, []int{watchfd}, registerRemove, 0); err != nil {
 		return err
 	}
 
-	syscall.Close(watchfd)
+	unix.Close(watchfd)
 
 	w.mu.Lock()
 	isDir := w.paths[watchfd].isDir
@@ -152,7 +153,7 @@ func (w *Watcher) Remove(name string) error {
 }
 
 // Watch all events (except NOTE_EXTEND, NOTE_LINK, NOTE_REVOKE)
-const noteAllEvents = syscall.NOTE_DELETE | syscall.NOTE_WRITE | syscall.NOTE_ATTRIB | syscall.NOTE_RENAME
+const noteAllEvents = unix.NOTE_DELETE | unix.NOTE_WRITE | unix.NOTE_ATTRIB | unix.NOTE_RENAME
 
 // keventWaitTime to block on each read from kevent
 var keventWaitTime = durationToTimespec(100 * time.Millisecond)
@@ -219,7 +220,7 @@ func (w *Watcher) addWatch(name string, flags uint32) (string, error) {
 			}
 		}
 
-		watchfd, err = syscall.Open(name, openMode, 0700)
+		watchfd, err = unix.Open(name, openMode, 0700)
 		if watchfd == -1 {
 			return "", err
 		}
@@ -227,9 +228,9 @@ func (w *Watcher) addWatch(name string, flags uint32) (string, error) {
 		isDir = fi.IsDir()
 	}
 
-	const registerAdd = syscall.EV_ADD | syscall.EV_CLEAR | syscall.EV_ENABLE
+	const registerAdd = unix.EV_ADD | unix.EV_CLEAR | unix.EV_ENABLE
 	if err := register(w.kq, []int{watchfd}, registerAdd, flags); err != nil {
-		syscall.Close(watchfd)
+		unix.Close(watchfd)
 		return "", err
 	}
 
@@ -245,8 +246,8 @@ func (w *Watcher) addWatch(name string, flags uint32) (string, error) {
 		// or if it was watched before, but perhaps only a NOTE_DELETE (watchDirectoryFiles)
 		w.mu.Lock()
 
-		watchDir := (flags&syscall.NOTE_WRITE) == syscall.NOTE_WRITE &&
-			(!alreadyWatching || (w.dirFlags[name]&syscall.NOTE_WRITE) != syscall.NOTE_WRITE)
+		watchDir := (flags&unix.NOTE_WRITE) == unix.NOTE_WRITE &&
+			(!alreadyWatching || (w.dirFlags[name]&unix.NOTE_WRITE) != unix.NOTE_WRITE)
 		// Store flags so this watch can be updated later
 		w.dirFlags[name] = flags
 		w.mu.Unlock()
@@ -263,13 +264,13 @@ func (w *Watcher) addWatch(name string, flags uint32) (string, error) {
 // readEvents reads from kqueue and converts the received kevents into
 // Event values that it sends down the Events channel.
 func (w *Watcher) readEvents() {
-	eventBuffer := make([]syscall.Kevent_t, 10)
+	eventBuffer := make([]unix.Kevent_t, 10)
 
 	for {
 		// See if there is a message on the "done" channel
 		select {
 		case <-w.done:
-			err := syscall.Close(w.kq)
+			err := unix.Close(w.kq)
 			if err != nil {
 				w.Errors <- err
 			}
@@ -282,7 +283,7 @@ func (w *Watcher) readEvents() {
 		// Get new events
 		kevents, err := read(w.kq, eventBuffer, &keventWaitTime)
 		// EINTR is okay, the syscall was interrupted before timeout expired.
-		if err != nil && err != syscall.EINTR {
+		if err != nil && err != unix.EINTR {
 			w.Errors <- err
 			continue
 		}
@@ -356,16 +357,16 @@ func (w *Watcher) readEvents() {
 // newEvent returns an platform-independent Event based on kqueue Fflags.
 func newEvent(name string, mask uint32) Event {
 	e := Event{Name: name}
-	if mask&syscall.NOTE_DELETE == syscall.NOTE_DELETE {
+	if mask&unix.NOTE_DELETE == unix.NOTE_DELETE {
 		e.Op |= Remove
 	}
-	if mask&syscall.NOTE_WRITE == syscall.NOTE_WRITE {
+	if mask&unix.NOTE_WRITE == unix.NOTE_WRITE {
 		e.Op |= Write
 	}
-	if mask&syscall.NOTE_RENAME == syscall.NOTE_RENAME {
+	if mask&unix.NOTE_RENAME == unix.NOTE_RENAME {
 		e.Op |= Rename
 	}
-	if mask&syscall.NOTE_ATTRIB == syscall.NOTE_ATTRIB {
+	if mask&unix.NOTE_ATTRIB == unix.NOTE_ATTRIB {
 		e.Op |= Chmod
 	}
 	return e
@@ -451,7 +452,7 @@ func (w *Watcher) internalWatch(name string, fileInfo os.FileInfo) (string, erro
 		flags := w.dirFlags[name]
 		w.mu.Unlock()
 
-		flags |= syscall.NOTE_DELETE | syscall.NOTE_RENAME
+		flags |= unix.NOTE_DELETE | unix.NOTE_RENAME
 		return w.addWatch(name, flags)
 	}
 
@@ -461,7 +462,7 @@ func (w *Watcher) internalWatch(name string, fileInfo os.FileInfo) (string, erro
 
 // kqueue creates a new kernel event queue and returns a descriptor.
 func kqueue() (kq int, err error) {
-	kq, err = syscall.Kqueue()
+	kq, err = unix.Kqueue()
 	if kq == -1 {
 		return kq, err
 	}
@@ -470,16 +471,16 @@ func kqueue() (kq int, err error) {
 
 // register events with the queue
 func register(kq int, fds []int, flags int, fflags uint32) error {
-	changes := make([]syscall.Kevent_t, len(fds))
+	changes := make([]unix.Kevent_t, len(fds))
 
 	for i, fd := range fds {
 		// SetKevent converts int to the platform-specific types:
-		syscall.SetKevent(&changes[i], fd, syscall.EVFILT_VNODE, flags)
+		unix.SetKevent(&changes[i], fd, unix.EVFILT_VNODE, flags)
 		changes[i].Fflags = fflags
 	}
 
 	// register the events
-	success, err := syscall.Kevent(kq, changes, nil, nil)
+	success, err := unix.Kevent(kq, changes, nil, nil)
 	if success == -1 {
 		return err
 	}
@@ -488,8 +489,8 @@ func register(kq int, fds []int, flags int, fflags uint32) error {
 
 // read retrieves pending events, or waits until an event occurs.
 // A timeout of nil blocks indefinitely, while 0 polls the queue.
-func read(kq int, events []syscall.Kevent_t, timeout *syscall.Timespec) ([]syscall.Kevent_t, error) {
-	n, err := syscall.Kevent(kq, nil, events, timeout)
+func read(kq int, events []unix.Kevent_t, timeout *unix.Timespec) ([]unix.Kevent_t, error) {
+	n, err := unix.Kevent(kq, nil, events, timeout)
 	if err != nil {
 		return nil, err
 	}
@@ -497,6 +498,6 @@ func read(kq int, events []syscall.Kevent_t, timeout *syscall.Timespec) ([]sysca
 }
 
 // durationToTimespec prepares a timeout value
-func durationToTimespec(d time.Duration) syscall.Timespec {
-	return syscall.NsecToTimespec(d.Nanoseconds())
+func durationToTimespec(d time.Duration) unix.Timespec {
+	return unix.NsecToTimespec(d.Nanoseconds())
 }

--- a/components/engine/vendor/github.com/fsnotify/fsnotify/open_mode_bsd.go
+++ b/components/engine/vendor/github.com/fsnotify/fsnotify/open_mode_bsd.go
@@ -6,6 +6,6 @@
 
 package fsnotify
 
-import "syscall"
+import "golang.org/x/sys/unix"
 
-const openMode = syscall.O_NONBLOCK | syscall.O_RDONLY
+const openMode = unix.O_NONBLOCK | unix.O_RDONLY

--- a/components/engine/vendor/github.com/fsnotify/fsnotify/open_mode_darwin.go
+++ b/components/engine/vendor/github.com/fsnotify/fsnotify/open_mode_darwin.go
@@ -6,7 +6,7 @@
 
 package fsnotify
 
-import "syscall"
+import "golang.org/x/sys/unix"
 
 // note: this constant is not defined on BSD
-const openMode = syscall.O_EVTONLY
+const openMode = unix.O_EVTONLY

--- a/components/engine/vendor/github.com/fsnotify/fsnotify/windows.go
+++ b/components/engine/vendor/github.com/fsnotify/fsnotify/windows.go
@@ -306,7 +306,7 @@ func (w *Watcher) remWatch(pathname string) error {
 		watch.mask = 0
 	} else {
 		name := filepath.Base(pathname)
-		w.sendEvent(watch.path+"\\"+name, watch.names[name]&sysFSIGNORED)
+		w.sendEvent(filepath.Join(watch.path, name), watch.names[name]&sysFSIGNORED)
 		delete(watch.names, name)
 	}
 	return w.startRead(watch)
@@ -316,7 +316,7 @@ func (w *Watcher) remWatch(pathname string) error {
 func (w *Watcher) deleteWatch(watch *watch) {
 	for name, mask := range watch.names {
 		if mask&provisional == 0 {
-			w.sendEvent(watch.path+"\\"+name, mask&sysFSIGNORED)
+			w.sendEvent(filepath.Join(watch.path, name), mask&sysFSIGNORED)
 		}
 		delete(watch.names, name)
 	}
@@ -453,7 +453,7 @@ func (w *Watcher) readEvents() {
 			raw := (*syscall.FileNotifyInformation)(unsafe.Pointer(&watch.buf[offset]))
 			buf := (*[syscall.MAX_PATH]uint16)(unsafe.Pointer(&raw.FileName))
 			name := syscall.UTF16ToString(buf[:raw.FileNameLength/2])
-			fullname := watch.path + "\\" + name
+			fullname := filepath.Join(watch.path, name)
 
 			var mask uint64
 			switch raw.Action {
@@ -491,7 +491,7 @@ func (w *Watcher) readEvents() {
 				}
 			}
 			if raw.Action == syscall.FILE_ACTION_RENAMED_NEW_NAME {
-				fullname = watch.path + "\\" + watch.rename
+				fullname = filepath.Join(watch.path, watch.rename)
 				sendNameEvent()
 			}
 


### PR DESCRIPTION
backport upstream fix:
* moby/moby/pull/34360 fix TestLogsFollowGoroutinesWithStdout in arm64

with cherry pick git commit https://github.com/moby/moby/pull/34360/commits/6e590d3:
```
$ git cherry-pick -s -x -Xsubtree=components/engine 6e590d3
```

no conflicts