### PR TITLE
[17.07] backport Fix requests for docker host ending with slash

### DIFF
--- a/components/cli/vendor/github.com/docker/docker/client/client.go
+++ b/components/cli/vendor/github.com/docker/docker/client/client.go
@@ -51,6 +51,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -219,9 +220,9 @@ func (cli *Client) getAPIPath(p string, query url.Values) string {
 	var apiPath string
 	if cli.version != "" {
 		v := strings.TrimPrefix(cli.version, "v")
-		apiPath = cli.basePath + "/v" + v + p
+		apiPath = path.Join(cli.basePath, "/v"+v+p)
 	} else {
-		apiPath = cli.basePath + p
+		apiPath = path.Join(cli.basePath, p)
 	}
 
 	u := &url.URL{

--- a/components/cli/vendor/github.com/docker/docker/client/ping.go
+++ b/components/cli/vendor/github.com/docker/docker/client/ping.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"path"
+
 	"github.com/docker/docker/api/types"
 	"golang.org/x/net/context"
 )
@@ -8,7 +10,7 @@ import (
 // Ping pings the server and returns the value of the "Docker-Experimental", "OS-Type" & "API-Version" headers
 func (cli *Client) Ping(ctx context.Context) (types.Ping, error) {
 	var ping types.Ping
-	req, err := cli.buildRequest("GET", cli.basePath+"/_ping", nil, nil)
+	req, err := cli.buildRequest("GET", path.Join(cli.basePath, "/_ping"), nil, nil)
 	if err != nil {
 		return ping, err
 	}

--- a/components/engine/client/client.go
+++ b/components/engine/client/client.go
@@ -51,6 +51,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -219,9 +220,9 @@ func (cli *Client) getAPIPath(p string, query url.Values) string {
 	var apiPath string
 	if cli.version != "" {
 		v := strings.TrimPrefix(cli.version, "v")
-		apiPath = cli.basePath + "/v" + v + p
+		apiPath = path.Join(cli.basePath, "/v"+v+p)
 	} else {
-		apiPath = cli.basePath + p
+		apiPath = path.Join(cli.basePath, p)
 	}
 
 	u := &url.URL{

--- a/components/engine/client/ping.go
+++ b/components/engine/client/ping.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"path"
+
 	"github.com/docker/docker/api/types"
 	"golang.org/x/net/context"
 )
@@ -8,7 +10,7 @@ import (
 // Ping pings the server and returns the value of the "Docker-Experimental", "OS-Type" & "API-Version" headers
 func (cli *Client) Ping(ctx context.Context) (types.Ping, error) {
 	var ping types.Ping
-	req, err := cli.buildRequest("GET", cli.basePath+"/_ping", nil, nil)
+	req, err := cli.buildRequest("GET", path.Join(cli.basePath, "/_ping"), nil, nil)
 	if err != nil {
 		return ping, err
 	}


### PR DESCRIPTION
backport fix:
* moby/moby/pull/34487 Fix requests for docker host ending with slash

with cherry pick of git commit https://github.com/moby/moby/pull/34487/commits/823e88d931 (no conflicts):
```
$ git cherry-pick -s -x -Xsubtree=components/engine 823e88d
```

and update of `components/cli/vendor/github.com/docker/docker` with the changes to `components/engine`