### PR TITLE
[17.07] vndr libnetwork to bring in lock fix

### DIFF
--- a/components/engine/vendor.conf
+++ b/components/engine/vendor.conf
@@ -27,7 +27,7 @@ github.com/imdario/mergo 0.2.1
 golang.org/x/sync de49d9dcd27d4f764488181bea099dfe6179bcf0
 
 #get libnetwork packages
-github.com/docker/libnetwork 230db20572a70538227b65ca72f7627c8b2bae41
+github.com/docker/libnetwork 4a242dba7739bb7d4351b260863b5e8789ea5abe
 github.com/docker/go-events 18b43f1bc85d9cdd42c05a6cd2d444c7a200a894
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/components/engine/vendor/github.com/docker/libnetwork/drivers/overlay/ov_network.go
+++ b/components/engine/vendor/github.com/docker/libnetwork/drivers/overlay/ov_network.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -81,6 +82,10 @@ func setDefaultVlan() {
 		logrus.Error("insufficient number of arguments")
 		os.Exit(1)
 	}
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	nsPath := os.Args[1]
 	ns, err := netns.GetFromPath(nsPath)
 	if err != nil {


### PR DESCRIPTION
vndr libnetwork to bring in fix:
* docker/libnetwork/pull/1913 [backport 17.07] Overlay fix for IP reuse

comparison of changes from the libnetwork repo: https://github.com/docker/libnetwork/compare/230db20...4a242db