### PR TITLE
[17.06] vndr libnetwork to bring in fix for overlay network ip reuse

### DIFF
--- a/components/engine/vendor.conf
+++ b/components/engine/vendor.conf
@@ -27,7 +27,7 @@ github.com/imdario/mergo 0.2.1
 golang.org/x/sync de49d9dcd27d4f764488181bea099dfe6179bcf0
 
 #get libnetwork packages
-github.com/docker/libnetwork 21026683470a66bf752e3d61e660ab07813cdc61
+github.com/docker/libnetwork 93976265048377e7644acfbfae2178a17fb04087
 github.com/docker/go-events 18b43f1bc85d9cdd42c05a6cd2d444c7a200a894
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/components/engine/vendor/github.com/docker/libnetwork/drivers/overlay/ov_network.go
+++ b/components/engine/vendor/github.com/docker/libnetwork/drivers/overlay/ov_network.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -81,6 +82,10 @@ func setDefaultVlan() {
 		logrus.Error("insufficient number of arguments")
 		os.Exit(1)
 	}
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	nsPath := os.Args[1]
 	ns, err := netns.GetFromPath(nsPath)
 	if err != nil {

--- a/components/engine/vendor/github.com/docker/libnetwork/drivers/overlay/peerdb.go
+++ b/components/engine/vendor/github.com/docker/libnetwork/drivers/overlay/peerdb.go
@@ -254,7 +254,7 @@ func (d *driver) peerOpRoutine(ctx context.Context, ch chan *peerOperation) {
 			case peerOperationADD:
 				err = d.peerAddOp(op.networkID, op.endpointID, op.peerIP, op.peerIPMask, op.peerMac, op.vtepIP, op.updateDB, op.l2Miss, op.l3Miss, op.localPeer)
 			case peerOperationDELETE:
-				err = d.peerDeleteOp(op.networkID, op.endpointID, op.peerIP, op.peerIPMask, op.peerMac, op.vtepIP, op.localPeer)
+				err = d.peerDeleteOp(op.networkID, op.endpointID, op.peerIP, op.peerIPMask, op.peerMac, op.vtepIP, op.updateDB)
 			}
 			if err != nil {
 				logrus.Warnf("Peer operation failed:%s op:%v", err, op)


### PR DESCRIPTION
vndr libnetwork to specifically bring in this fix:
* docker/libnetwork#1912 [backport 17.06] Overlay fix for IP reuse

comparison of changes from the libnetwork repo: https://github.com/docker/libnetwork/compare/2102668...9397626