### PR TITLE
[17.06] Fix concurrent map access on read

### DIFF
--- a/components/engine/pkg/jsonlog/jsonlog.go
+++ b/components/engine/pkg/jsonlog/jsonlog.go
@@ -39,4 +39,5 @@ func (jl *JSONLog) Reset() {
 	jl.Log = ""
 	jl.Stream = ""
 	jl.Created = time.Time{}
+	jl.Attrs = nil
 }


### PR DESCRIPTION
This makes a copy of the jsonlog attributes.
This is required since log reads are always async and maps are passed by
reference.