### PR TITLE
[17.07] Fix concurrent map access on read

### DIFF
--- a/components/engine/daemon/logger/jsonfilelog/read.go
+++ b/components/engine/daemon/logger/jsonfilelog/read.go
@@ -27,11 +27,19 @@ func decodeLogLine(dec *json.Decoder, l *jsonlog.JSONLog) (*logger.Message, erro
 	if err := dec.Decode(l); err != nil {
 		return nil, err
 	}
+
+	var attrs map[string]string
+	if len(l.Attrs) > 0 {
+		attrs = make(map[string]string, len(l.Attrs))
+		for k, v := range l.Attrs {
+			attrs[k] = v
+		}
+	}
 	msg := &logger.Message{
 		Source:    l.Stream,
 		Timestamp: l.Created,
 		Line:      []byte(l.Log),
-		Attrs:     l.Attrs,
+		Attrs:     attrs,
 	}
 	return msg, nil
 }


### PR DESCRIPTION
This makes a copy of the jsonlog attributes.
This is required since log reads are always async and maps are passed by
reference.