### PR TITLE
[17.09] Fix metalinter conversion errors

### DIFF
--- a/components/engine/Dockerfile.aarch64
+++ b/components/engine/Dockerfile.aarch64
@@ -173,7 +173,7 @@ RUN ./contrib/download-frozen-image-v2.sh /docker-frozen-images \
 # Please edit hack/dockerfile/install-binaries.sh to update them.
 COPY hack/dockerfile/binaries-commits /tmp/binaries-commits
 COPY hack/dockerfile/install-binaries.sh /tmp/install-binaries.sh
-RUN /tmp/install-binaries.sh tomlv vndr runc containerd tini proxy dockercli
+RUN /tmp/install-binaries.sh tomlv vndr runc containerd tini proxy dockercli gometalinter
 ENV PATH=/usr/local/cli:$PATH
 
 # Wrap all commands in the "docker-in-docker" script to allow nested containers

--- a/components/engine/Dockerfile.armhf
+++ b/components/engine/Dockerfile.armhf
@@ -162,7 +162,7 @@ RUN ./contrib/download-frozen-image-v2.sh /docker-frozen-images \
 # Please edit hack/dockerfile/install-binaries.sh to update them.
 COPY hack/dockerfile/binaries-commits /tmp/binaries-commits
 COPY hack/dockerfile/install-binaries.sh /tmp/install-binaries.sh
-RUN /tmp/install-binaries.sh tomlv vndr runc containerd tini proxy dockercli
+RUN /tmp/install-binaries.sh tomlv vndr runc containerd tini proxy dockercli gometalinter
 ENV PATH=/usr/local/cli:$PATH
 
 ENTRYPOINT ["hack/dind"]

--- a/components/engine/Dockerfile.ppc64le
+++ b/components/engine/Dockerfile.ppc64le
@@ -160,7 +160,7 @@ RUN ./contrib/download-frozen-image-v2.sh /docker-frozen-images \
 # Please edit hack/dockerfile/install-binaries.sh to update them.
 COPY hack/dockerfile/binaries-commits /tmp/binaries-commits
 COPY hack/dockerfile/install-binaries.sh /tmp/install-binaries.sh
-RUN /tmp/install-binaries.sh tomlv vndr runc containerd tini proxy dockercli
+RUN /tmp/install-binaries.sh tomlv vndr runc containerd tini proxy dockercli gometalinter
 ENV PATH=/usr/local/cli:$PATH
 
 # Wrap all commands in the "docker-in-docker" script to allow nested containers

--- a/components/engine/Dockerfile.s390x
+++ b/components/engine/Dockerfile.s390x
@@ -153,7 +153,7 @@ RUN ./contrib/download-frozen-image-v2.sh /docker-frozen-images \
 # Please edit hack/dockerfile/install-binaries.sh to update them.
 COPY hack/dockerfile/binaries-commits /tmp/binaries-commits
 COPY hack/dockerfile/install-binaries.sh /tmp/install-binaries.sh
-RUN /tmp/install-binaries.sh tomlv vndr runc containerd tini proxy dockercli
+RUN /tmp/install-binaries.sh tomlv vndr runc containerd tini proxy dockercli gometalinter
 ENV PATH=/usr/local/cli:$PATH
 
 # Wrap all commands in the "docker-in-docker" script to allow nested containers

--- a/components/engine/daemon/graphdriver/overlay/copy.go
+++ b/components/engine/daemon/graphdriver/overlay/copy.go
@@ -157,9 +157,10 @@ func copyDir(srcDir, dstDir string, flags copyFlags) error {
 		}
 
 		// system.Chtimes doesn't support a NOFOLLOW flag atm
+		// nolint: unconvert
 		if !isSymlink {
-			aTime := time.Unix(stat.Atim.Sec, stat.Atim.Nsec)
-			mTime := time.Unix(stat.Mtim.Sec, stat.Mtim.Nsec)
+			aTime := time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec))
+			mTime := time.Unix(int64(stat.Mtim.Sec), int64(stat.Mtim.Nsec))
 			if err := system.Chtimes(dstPath, aTime, mTime); err != nil {
 				return err
 			}

--- a/components/engine/pkg/archive/archive_unix.go
+++ b/components/engine/pkg/archive/archive_unix.go
@@ -50,8 +50,8 @@ func setHeaderForSpecialDevice(hdr *tar.Header, name string, stat interface{}) (
 		// Currently go does not fill in the major/minors
 		if s.Mode&unix.S_IFBLK != 0 ||
 			s.Mode&unix.S_IFCHR != 0 {
-			hdr.Devmajor = int64(major(s.Rdev))
-			hdr.Devminor = int64(minor(s.Rdev))
+			hdr.Devmajor = int64(major(uint64(s.Rdev))) // nolint: unconvert
+			hdr.Devminor = int64(minor(uint64(s.Rdev))) // nolint: unconvert
 		}
 	}
 


### PR DESCRIPTION
## Cherry-pick command:
```
git cherry-pick -x -s -Xsubtree="components/engine" 7c9e64a2e1891bf1020d9312a18741c734fa1cd6 0c0047e67f8ee73f73465ac60ccebbd16260ab46 0120303d8ea4a1d9f8920ac4dba80521072e8536
```

*NOTE*: Cherry pick was clean

## Information:
Addresses issues where armhf packages were not being built correctly due to `gometalinter` failures.

Relates to: https://github.com/moby/moby/pull/34625#issuecomment-326772200