### PR TITLE
[17.09] Fix test run environment

### DIFF
--- a/components/engine/integration-cli/docker_cli_run_test.go
+++ b/components/engine/integration-cli/docker_cli_run_test.go
@@ -824,7 +824,7 @@ func (s *DockerSuite) TestRunEnvironment(c *check.C) {
 	})
 	result.Assert(c, icmd.Success)
 
-	actualEnv := strings.Split(strings.TrimSpace(result.Combined()), "\n")
+	actualEnv := strings.Split(strings.TrimSuffix(result.Stdout(), "\n"), "\n")
 	sort.Strings(actualEnv)
 
 	goodEnv := []string{


### PR DESCRIPTION
## Cherry pick:
```
❯ git cherry-pick -x -s -Xsubtree="components/engine" fff605c3b3557acf6bf793813d695fba59d7fa21
[fix_test_run_environment dff328c8a6] Fix a bad assumption
 Author: Daniel Nephin <dnephin@docker.com>
 Date: Wed Sep 6 17:32:56 2017 -0400
 1 file changed, 1 insertion(+), 1 deletion(-)
```

**NOTE**: Was clean

## Overview:

If the empty variable happens to be sorted to the end of the list then TrimSpace()
would remove it. Instead only strip the single trailing newline.

Signed-off-by: Daniel Nephin <dnephin@docker.com>
(cherry picked from commit fff605c3b3557acf6bf793813d695fba59d7fa21)
Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>

ping @dnephin @vieux @andrewhsu 