### PR TITLE
[17.09] backport fix to get static builds going

### DIFF
--- a/components/engine/Dockerfile
+++ b/components/engine/Dockerfile
@@ -74,7 +74,7 @@ RUN apt-get update && apt-get install -y \
 	&& pip install awscli==1.10.15
 
 # Get lvm2 sources to build statically linked devmapper library
-ENV LVM2_VERSION 2.02.173
+ENV LVM2_VERSION 2.02.168
 RUN mkdir -p /usr/local/lvm2 \
 	&& curl -fsSL "https://mirrors.kernel.org/sourceware/lvm2/LVM2.${LVM2_VERSION}.tgz" \
 		| tar -xzC /usr/local/lvm2 --strip-components=1

--- a/components/engine/Dockerfile.aarch64
+++ b/components/engine/Dockerfile.aarch64
@@ -55,7 +55,7 @@ RUN apt-get update && apt-get install -y \
 	--no-install-recommends
 
 # Get lvm2 sources to build statically linked devmapper library
-ENV LVM2_VERSION 2.02.173
+ENV LVM2_VERSION 2.02.168
 RUN mkdir -p /usr/local/lvm2 \
 	&& curl -fsSL "https://mirrors.kernel.org/sourceware/lvm2/LVM2.${LVM2_VERSION}.tgz" \
 		| tar -xzC /usr/local/lvm2 --strip-components=1

--- a/components/engine/Dockerfile.armhf
+++ b/components/engine/Dockerfile.armhf
@@ -54,7 +54,7 @@ RUN apt-get update && apt-get install -y \
 	&& pip install awscli==1.10.15
 
 # Get lvm2 sources to build statically linked devmapper library
-ENV LVM2_VERSION 2.02.173
+ENV LVM2_VERSION 2.02.168
 RUN mkdir -p /usr/local/lvm2 \
 	&& curl -fsSL "https://mirrors.kernel.org/sourceware/lvm2/LVM2.${LVM2_VERSION}.tgz" \
 		| tar -xzC /usr/local/lvm2 --strip-components=1

--- a/components/engine/Dockerfile.ppc64le
+++ b/components/engine/Dockerfile.ppc64le
@@ -54,7 +54,7 @@ RUN apt-get update && apt-get install -y \
 	--no-install-recommends
 
 # Get lvm2 sources to build statically linked devmapper library
-ENV LVM2_VERSION 2.02.173
+ENV LVM2_VERSION 2.02.168
 RUN mkdir -p /usr/local/lvm2 \
 	&& curl -fsSL "https://mirrors.kernel.org/sourceware/lvm2/LVM2.${LVM2_VERSION}.tgz" \
 		| tar -xzC /usr/local/lvm2 --strip-components=1

--- a/components/engine/Dockerfile.s390x
+++ b/components/engine/Dockerfile.s390x
@@ -65,7 +65,7 @@ RUN set -x \
 	&& rm -rf "$SECCOMP_PATH"
 
 # Get lvm2 sources to build statically linked devmapper library
-ENV LVM2_VERSION 2.02.173
+ENV LVM2_VERSION 2.02.168
 RUN mkdir -p /usr/local/lvm2 \
 	&& curl -fsSL "https://mirrors.kernel.org/sourceware/lvm2/LVM2.${LVM2_VERSION}.tgz" \
 		| tar -xzC /usr/local/lvm2 --strip-components=1


### PR DESCRIPTION
To address:
* https://github.com/moby/moby/pull/34844 Fix fetching LVM2 sources

cherry-picked git commit moby/moby@a436d8a

```
$ git cherry-pick -s -x -Xsubtree=components/engine a436d8a
```

no conflicts with the cherry-pick