### PR TITLE
[17.09] Fixed `raw` mode splunk logger

### DIFF
--- a/components/engine/daemon/logger/splunk/splunk.go
+++ b/components/engine/daemon/logger/splunk/splunk.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -363,6 +364,11 @@ func (l *splunkLoggerJSON) Log(msg *logger.Message) error {
 }
 
 func (l *splunkLoggerRaw) Log(msg *logger.Message) error {
+	// empty or whitespace-only messages are not accepted by HEC
+	if strings.TrimSpace(string(msg.Line)) == "" {
+		return nil
+	}
+
 	message := l.createSplunkMessage(msg)
 
 	message.Event = string(append(l.prefix, msg.Line...))

--- a/components/engine/daemon/logger/splunk/splunk_test.go
+++ b/components/engine/daemon/logger/splunk/splunk_test.go
@@ -716,12 +716,19 @@ func TestRawFormatWithoutTag(t *testing.T) {
 	if err := loggerDriver.Log(&logger.Message{Line: []byte("notjson"), Source: "stdout", Timestamp: message2Time}); err != nil {
 		t.Fatal(err)
 	}
+	message3Time := time.Now()
+	if err := loggerDriver.Log(&logger.Message{Line: []byte(" "), Source: "stdout", Timestamp: message3Time}); err != nil {
+		t.Fatal(err)
+	}
 
 	err = loggerDriver.Close()
 	if err != nil {
 		t.Fatal(err)
 	}
 
+	// message3 would have an empty or whitespace only string in the "event" field
+	// both of which are not acceptable to HEC
+	// thus here we must expect 2 messages, not 3
 	if len(hec.messages) != 2 {
 		t.Fatal("Expected two messages")
 	}


### PR DESCRIPTION
back port of https://github.com/moby/moby/pull/34520 for 17.09

Splunk HEC does not accept log events with an empty string or a
whitespace-only string.

(cherry picked from commit 5f6d6a5093a4db799f9c1a6bb82eed1eea13ec0c)
