### PR TITLE
[17.06] Relabel config files.

### DIFF
--- a/components/engine/daemon/container_operations_unix.go
+++ b/components/engine/daemon/container_operations_unix.go
@@ -286,6 +286,8 @@ func (daemon *Daemon) setupConfigDir(c *container.Container) (setupErr error) {
 		if err := os.Chown(fPath, rootUID+uid, rootGID+gid); err != nil {
 			return errors.Wrap(err, "error setting ownership for config")
 		}
+
+		label.Relabel(fPath, c.MountLabel, false)
 	}
 
 	return nil


### PR DESCRIPTION
back port of https://github.com/moby/moby/pull/34732

Without relabel these files, SELinux-enabled containers will show
"permission denied" errors for configuration files mounted with
`docker server create ... --config ... ...`.

(cherry picked from commit 472c03a8c364090afb88258b3dd9748183c29d05)
