### PR TITLE
[17.09] Set selinux label on local volumes from mounts API

### DIFF
--- a/components/engine/daemon/volumes.go
+++ b/components/engine/daemon/volumes.go
@@ -206,6 +206,9 @@ func (daemon *Daemon) registerMountPoints(container *container.Container, hostCo
 			}); ok {
 				mp.Source = cv.CachedPath()
 			}
+			if mp.Driver == volume.DefaultDriverName {
+				setBindModeIfNull(mp)
+			}
 		}
 
 		binds[mp.Destination] = true

--- a/components/engine/volume/local/local.go
+++ b/components/engine/volume/local/local.go
@@ -334,6 +334,11 @@ func (v *localVolume) Path() string {
 	return v.path
 }
 
+// CachedPath returns the data location
+func (v *localVolume) CachedPath() string {
+	return v.path
+}
+
 // Mount implements the localVolume interface, returning the data location.
 // If there are any provided mount options, the resources will be mounted at this point
 func (v *localVolume) Mount(id string) (string, error) {


### PR DESCRIPTION
cherry-pick of:

- https://github.com/moby/moby/pull/34684 ("Set selinux label on local volumes from mounts API")
- https://github.com/moby/moby/pull/34761  ("Some cleanup of mount create API test")

the last one was needed to get a clean cherry-pick

ping @cpuguy83 PTAL