### PR TITLE
[17.09] vndr docker/swarmkit to dcd1f2d56afc08827d060fdb8ad222b00b1b6000 for snapshot size fix

### DIFF
--- a/components/engine/vendor.conf
+++ b/components/engine/vendor.conf
@@ -108,7 +108,7 @@ github.com/stevvooe/continuity cd7a8e21e2b6f84799f5dd4b65faf49c8d3ee02d
 github.com/tonistiigi/fsutil 0ac4c11b053b9c5c7c47558f81f96c7100ce50fb
 
 # cluster
-github.com/docker/swarmkit ddb4539f883b18ea40af44ee6de63ac2adc8dc1e
+github.com/docker/swarmkit dcd1f2d56afc08827d060fdb8ad222b00b1b6000
 github.com/gogo/protobuf v0.4
 github.com/cloudflare/cfssl 7fb22c8cba7ecaf98e4082d22d65800cf45e042a
 github.com/google/certificate-transparency d90e65c3a07988180c5b1ece71791c0b6506826e

--- a/components/engine/vendor/github.com/docker/swarmkit/ca/keyreadwriter.go
+++ b/components/engine/vendor/github.com/docker/swarmkit/ca/keyreadwriter.go
@@ -187,10 +187,7 @@ func (k *KeyReadWriter) ViewAndRotateKEK(cb func(KEKData, PEMKeyHeaders) (KEKDat
 		return err
 	}
 
-	if err := k.writeKey(keyBlock, updatedKEK, updatedHeaderObj); err != nil {
-		return err
-	}
-	return nil
+	return k.writeKey(keyBlock, updatedKEK, updatedHeaderObj)
 }
 
 // ViewAndUpdateHeaders updates the header manager, and updates any headers on the existing key

--- a/components/engine/vendor/github.com/docker/swarmkit/manager/allocator/network.go
+++ b/components/engine/vendor/github.com/docker/swarmkit/manager/allocator/network.go
@@ -175,11 +175,7 @@ func (a *Allocator) doNetworkInit(ctx context.Context) (err error) {
 	if err := a.allocateServices(ctx, false); err != nil {
 		return err
 	}
-	if err := a.allocateTasks(ctx, false); err != nil {
-		return err
-	}
-
-	return nil
+	return a.allocateTasks(ctx, false)
 }
 
 func (a *Allocator) doNetworkAlloc(ctx context.Context, ev events.Event) {

--- a/components/engine/vendor/github.com/docker/swarmkit/manager/controlapi/network.go
+++ b/components/engine/vendor/github.com/docker/swarmkit/manager/controlapi/network.go
@@ -96,11 +96,7 @@ func validateNetworkSpec(spec *api.NetworkSpec, pg plugingetter.PluginGetter) er
 		return err
 	}
 
-	if err := validateIPAM(spec.IPAM, pg); err != nil {
-		return err
-	}
-
-	return nil
+	return validateIPAM(spec.IPAM, pg)
 }
 
 // CreateNetwork creates and returns a Network based on the provided NetworkSpec.

--- a/components/engine/vendor/github.com/docker/swarmkit/manager/controlapi/service.go
+++ b/components/engine/vendor/github.com/docker/swarmkit/manager/controlapi/service.go
@@ -56,10 +56,7 @@ func validateResourceRequirements(r *api.ResourceRequirements) error {
 	if err := validateResources(r.Limits); err != nil {
 		return err
 	}
-	if err := validateResources(r.Reservations); err != nil {
-		return err
-	}
-	return nil
+	return validateResources(r.Reservations)
 }
 
 func validateRestartPolicy(rp *api.RestartPolicy) error {
@@ -161,11 +158,7 @@ func validateContainerSpec(taskSpec api.TaskSpec) error {
 		return err
 	}
 
-	if err := validateHealthCheck(container.Healthcheck); err != nil {
-		return err
-	}
-
-	return nil
+	return validateHealthCheck(container.Healthcheck)
 }
 
 // validateImage validates image name in containerSpec
@@ -481,11 +474,7 @@ func validateServiceSpec(spec *api.ServiceSpec) error {
 	if err := validateEndpointSpec(spec.Endpoint); err != nil {
 		return err
 	}
-	if err := validateMode(spec); err != nil {
-		return err
-	}
-
-	return nil
+	return validateMode(spec)
 }
 
 // checkPortConflicts does a best effort to find if the passed in spec has port

--- a/components/engine/vendor/github.com/docker/swarmkit/manager/dispatcher/dispatcher.go
+++ b/components/engine/vendor/github.com/docker/swarmkit/manager/dispatcher/dispatcher.go
@@ -854,10 +854,7 @@ func (d *Dispatcher) Assignments(r *api.AssignmentsRequest, stream api.Dispatche
 		appliesTo = msg.ResultsIn
 		msg.Type = assignmentType
 
-		if err := stream.Send(&msg); err != nil {
-			return err
-		}
-		return nil
+		return stream.Send(&msg)
 	}
 
 	// TODO(aaronl): Also send node secrets that should be exposed to

--- a/components/engine/vendor/github.com/docker/swarmkit/manager/manager.go
+++ b/components/engine/vendor/github.com/docker/swarmkit/manager/manager.go
@@ -54,6 +54,9 @@ import (
 const (
 	// defaultTaskHistoryRetentionLimit is the number of tasks to keep.
 	defaultTaskHistoryRetentionLimit = 5
+
+	// Default value for grpc max message size.
+	grpcMaxMessageSize = 128 << 20
 )
 
 // RemoteAddrs provides a listening address and an optional advertise address
@@ -231,6 +234,7 @@ func New(config *Config) (*Manager, error) {
 		grpc.Creds(config.SecurityConfig.ServerTLSCreds),
 		grpc.StreamInterceptor(grpc_prometheus.StreamServerInterceptor),
 		grpc.UnaryInterceptor(grpc_prometheus.UnaryServerInterceptor),
+		grpc.MaxMsgSize(grpcMaxMessageSize),
 	}
 
 	m := &Manager{

--- a/components/engine/vendor/github.com/docker/swarmkit/manager/orchestrator/update/updater.go
+++ b/components/engine/vendor/github.com/docker/swarmkit/manager/orchestrator/update/updater.go
@@ -384,10 +384,7 @@ func (u *Updater) updateTask(ctx context.Context, slot orchestrator.Slot, update
 				return errors.New("service was deleted")
 			}
 
-			if err := store.CreateTask(tx, updated); err != nil {
-				return err
-			}
-			return nil
+			return store.CreateTask(tx, updated)
 		})
 		if err != nil {
 			return err

--- a/components/engine/vendor/github.com/docker/swarmkit/manager/scheduler/scheduler.go
+++ b/components/engine/vendor/github.com/docker/swarmkit/manager/scheduler/scheduler.go
@@ -92,11 +92,7 @@ func (s *Scheduler) setupTasksList(tx store.ReadTx) error {
 		tasksByNode[t.NodeID][t.ID] = t
 	}
 
-	if err := s.buildNodeSet(tx, tasksByNode); err != nil {
-		return err
-	}
-
-	return nil
+	return s.buildNodeSet(tx, tasksByNode)
 }
 
 // Run is the scheduler event loop.

--- a/components/engine/vendor/github.com/docker/swarmkit/manager/state/raft/raft.go
+++ b/components/engine/vendor/github.com/docker/swarmkit/manager/state/raft/raft.go
@@ -1283,10 +1283,7 @@ func (n *Node) reportNewAddress(ctx context.Context, id uint64) error {
 		return err
 	}
 	newAddr := net.JoinHostPort(newHost, officialPort)
-	if err := n.transport.UpdatePeerAddr(id, newAddr); err != nil {
-		return err
-	}
-	return nil
+	return n.transport.UpdatePeerAddr(id, newAddr)
 }
 
 // ProcessRaftMessage calls 'Step' which advances the
@@ -1848,10 +1845,7 @@ func (n *Node) applyAddNode(cc raftpb.ConfChange) error {
 		return nil
 	}
 
-	if err = n.registerNode(member); err != nil {
-		return err
-	}
-	return nil
+	return n.registerNode(member)
 }
 
 // applyUpdateNode is called when we receive a ConfChange from a member in the

--- a/components/engine/vendor/github.com/docker/swarmkit/manager/state/raft/storage/storage.go
+++ b/components/engine/vendor/github.com/docker/swarmkit/manager/state/raft/storage/storage.go
@@ -226,10 +226,7 @@ func (e *EncryptedRaftLogger) SaveSnapshot(snapshot raftpb.Snapshot) error {
 	if err := snapshotter.SaveSnap(snapshot); err != nil {
 		return err
 	}
-	if err := e.wal.ReleaseLockTo(snapshot.Metadata.Index); err != nil {
-		return err
-	}
-	return nil
+	return e.wal.ReleaseLockTo(snapshot.Metadata.Index)
 }
 
 // GC garbage collects snapshots and wals older than the provided index and term

--- a/components/engine/vendor/github.com/docker/swarmkit/manager/state/raft/transport/transport.go
+++ b/components/engine/vendor/github.com/docker/swarmkit/manager/state/raft/transport/transport.go
@@ -235,10 +235,7 @@ func (t *Transport) UpdatePeerAddr(id uint64, addr string) error {
 	if !ok {
 		return ErrIsNotFound
 	}
-	if err := p.updateAddr(addr); err != nil {
-		return err
-	}
-	return nil
+	return p.updateAddr(addr)
 }
 
 // PeerConn returns raw grpc connection to peer.


### PR DESCRIPTION
To bring in upstream fix:
* https://github.com/docker/swarmkit/pull/2378 [17.06] backport fixes for max grpc message size and lint errors

Updated `vndr` of docker/swarmkit:
```
$ cd components/engine
$ vi vendor.conf # update hash for docker/swarmkit
$ make BIND_DIR=. shell
$ vndr github.com/docker/swarmkit
```

comparing changes in vendor update: https://github.com/docker/swarmkit/compare/ddb4539f883b18ea40af44ee6de63ac2adc8dc1e... dcd1f2d56afc08827d060fdb8ad222b00b1b6000 
