### PR TITLE
[17.09] vndr Microsoft/hcsshim to v0.6.5

### DIFF
--- a/components/engine/vendor.conf
+++ b/components/engine/vendor.conf
@@ -1,6 +1,6 @@
 # the following lines are in sorted order, FYI
 github.com/Azure/go-ansiterm 19f72df4d05d31cbe1c56bfc8045c96babff6c7e
-github.com/Microsoft/hcsshim v0.6.3
+github.com/Microsoft/hcsshim v0.6.5
 github.com/Microsoft/go-winio v0.4.5
 github.com/moby/buildkit da2b9dc7dab99e824b2b1067ad7d0523e32dd2d9 https://github.com/dmcgowan/buildkit.git
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76

--- a/components/engine/vendor/github.com/Microsoft/hcsshim/interface.go
+++ b/components/engine/vendor/github.com/Microsoft/hcsshim/interface.go
@@ -30,11 +30,12 @@ type Layer struct {
 }
 
 type MappedDir struct {
-	HostPath         string
-	ContainerPath    string
-	ReadOnly         bool
-	BandwidthMaximum uint64
-	IOPSMaximum      uint64
+	HostPath          string
+	ContainerPath     string
+	ReadOnly          bool
+	BandwidthMaximum  uint64
+	IOPSMaximum       uint64
+	CreateInUtilityVM bool
 }
 
 type MappedPipe struct {


### PR DESCRIPTION
To bring in fixes for windows

Effectively backporting these changes upstream:
* https://github.com/moby/moby/pull/34771 Revendor Microsoft/hcsshim @ v0.6.4
* https://github.com/moby/moby/pull/34775 Update hcsshim to v0.6.5

Comparison of changes in upstream: https://github.com/Microsoft/hcsshim/compare/v0.6.3...v0.6.5

This is how i did it:
```
$ cd components/engine
$ vi vendor.conf
$ make BIND_DIR=. shell
$ vndr github.com/Microsoft/hcsshim
```