### PR TITLE
WIP Explicitly add --detach to service CLI calls

### DIFF
--- a/components/engine/integration-cli/docker_cli_service_scale_test.go
+++ b/components/engine/integration-cli/docker_cli_service_scale_test.go
@@ -27,10 +27,10 @@ func (s *DockerSwarmSuite) TestServiceScale(c *check.C) {
 	out, err = d.Cmd(service2Args...)
 	c.Assert(err, checker.IsNil)
 
-	out, err = d.Cmd("service", "scale", "TestService1=2")
+	out, err = d.Cmd("service", "scale", "--detach", "TestService1=2")
 	c.Assert(err, checker.IsNil)
 
-	out, err = d.Cmd("service", "scale", "TestService1=foobar")
+	out, err = d.Cmd("service", "scale", "--detach", "TestService1=foobar")
 	c.Assert(err, checker.NotNil)
 
 	str := fmt.Sprintf("%s: invalid replicas value %s", service1Name, "foobar")
@@ -38,7 +38,7 @@ func (s *DockerSwarmSuite) TestServiceScale(c *check.C) {
 		c.Errorf("got: %s, expected has sub string: %s", out, str)
 	}
 
-	out, err = d.Cmd("service", "scale", "TestService1=-1")
+	out, err = d.Cmd("service", "scale", "--detach", "TestService1=-1")
 	c.Assert(err, checker.NotNil)
 
 	str = fmt.Sprintf("%s: invalid replicas value %s", service1Name, "-1")
@@ -47,7 +47,7 @@ func (s *DockerSwarmSuite) TestServiceScale(c *check.C) {
 	}
 
 	// TestService2 is a global mode
-	out, err = d.Cmd("service", "scale", "TestService2=2")
+	out, err = d.Cmd("service", "scale", "--detach", "TestService2=2")
 	c.Assert(err, checker.NotNil)
 
 	str = fmt.Sprintf("%s: scale can only be used with replicated mode\n", service2Name)

--- a/components/engine/integration-cli/docker_cli_swarm_test.go
+++ b/components/engine/integration-cli/docker_cli_swarm_test.go
@@ -2033,7 +2033,7 @@ func (s *DockerSwarmSuite) TestSwarmClusterEventsService(c *check.C) {
 
 	// scale service
 	t2 := daemonUnixTime(c)
-	out, err = d.Cmd("service", "scale", "test=3")
+	out, err = d.Cmd("service", "scale", "--detach", "test=3")
 	c.Assert(err, checker.IsNil, check.Commentf(out))
 
 	out = waitForEvent(c, d, t2, "-f scope=swarm", "service update "+serviceID, defaultRetryCount)


### PR DESCRIPTION
##NOTE: this is a PR to just test `tests`

The behavior of service (create/update/scale) was changed in a recent PR
to docker/cli. This commit serves to remedy test failures experienced
when attempting to use service calls.

Should not affect current behavior.

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>
(cherry picked from commit e5b3ebbc649e4b1a10d4cdca342a153c301ec225)
Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>