### PR TITLE
[17.10] ensure channel is allocated

### DIFF
--- a/components/cli/cli/command/container/run.go
+++ b/components/cli/cli/command/container/run.go
@@ -290,8 +290,11 @@ func attachContainer(
 		return nil, errAttach
 	}
 
+	ch := make(chan error, 1)
+	*errCh = ch
+
 	go func() {
-		*errCh <- func() error {
+		ch <- func() error {
 			streamer := hijackedIOStreamer{
 				streams:      dockerCli,
 				inputStream:  in,


### PR DESCRIPTION
To remedy hanging tests as addressed in https://github.com/docker/cli/pull/577

Signed-off-by: Stephen J Day <stephen.day@docker.com>
(cherry picked from commit e78772af4dca453ed97ff25b03adbaec2054859a)
Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>