### PR TITLE
[17.10] backport doc fixes and shell completion script fixes

### DIFF
--- a/components/cli/contrib/completion/bash/docker
+++ b/components/cli/contrib/completion/bash/docker
@@ -3224,7 +3224,7 @@ _docker_service_rm() {
 _docker_service_rollback() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--detach=false -d --help --quit -q" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--detach -d --help --quit -q" -- "$cur" ) )
 			;;
 		*)
 			local counter=$( __docker_pos_first_nonflag )
@@ -3238,7 +3238,7 @@ _docker_service_rollback() {
 _docker_service_scale() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--detach=false -d=false --help" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--detach -d --help" -- "$cur" ) )
 			;;
 		*)
 			__docker_complete_services
@@ -3339,7 +3339,7 @@ _docker_service_update_and_create() {
 	"
 
 	local boolean_options="
-		--detach=false -d=false
+		--detach -d
 		--help
 		--no-healthcheck
 		--read-only

--- a/components/cli/contrib/completion/bash/docker
+++ b/components/cli/contrib/completion/bash/docker
@@ -4345,16 +4345,20 @@ _docker_stack_deploy() {
 			_filedir yml
 			return
 			;;
+		--resolve-image)
+			COMPREPLY=( $( compgen -W "always changed never" -- "$cur" ) )
+			return
+			;;
 	esac
 
 	case "$cur" in
 		-*)
-			local options="--compose-file -c --help --prune --with-registry-auth"
+			local options="--compose-file -c --help --prune --resolve-image --with-registry-auth"
 			__docker_daemon_is_experimental && options+=" --bundle-file"
 			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )
 			;;
 		*)
-			local counter=$(__docker_pos_first_nonflag '--compose-file|-c|--bundle-file')
+			local counter=$(__docker_pos_first_nonflag '--bundle-file|--compose-file|-c|--resolve-image')
 			if [ "$cword" -eq "$counter" ]; then
 				__docker_complete_stacks
 			fi

--- a/components/cli/contrib/completion/bash/docker
+++ b/components/cli/contrib/completion/bash/docker
@@ -4188,17 +4188,17 @@ _docker_secret() {
 
 _docker_secret_create() {
 	case "$prev" in
-		--label|-l)
+		--driver|-d|--label|-l)
 			return
 			;;
 	esac
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--help --label -l" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--driver -d --help --label -l" -- "$cur" ) )
 			;;
 		*)
-			local counter=$(__docker_pos_first_nonflag '--label|-l')
+			local counter=$(__docker_pos_first_nonflag '--driver|-d|--label|-l')
 			if [ "$cword" -eq "$((counter + 1))" ]; then
 				_filedir
 			fi

--- a/components/cli/docs/deprecated.md
+++ b/components/cli/docs/deprecated.md
@@ -24,12 +24,15 @@ see [Feature Deprecation Policy](https://docs.docker.com/engine/#feature-depreca
 
 **Deprecated In Release: v17.05.0**
 
-**Disabled by default in release: [v17.09](https://github.com/docker/docker-ce/releases/tag/v17.09.0-ce)**
+**Disabled by default in release: [v17.10](https://github.com/docker/docker-ce/releases/tag/v17.10.0-ce)**
 
 Docker 17.05.0 added an optional `--detach=false` option to make the
 `docker service create` and `docker service update` work synchronously. This
-option will be enable by default in Docker 17.09, at which point the `--detach`
+option will be enabled by default in Docker 17.10, at which point the `--detach`
 flag can be used to use the previous (asynchronous) behavior.
+
+The default for this option will also be changed accordingly for `docker service rollback`
+and `docker service scale` in Docker 17.10.
 
 ### `-g` and `--graph` flags on `dockerd`
 

--- a/components/cli/docs/reference/commandline/dockerd.md
+++ b/components/cli/docs/reference/commandline/dockerd.md
@@ -967,7 +967,7 @@ Will make `hyperv` the default isolation technology on Windows. If no isolation
 value is specified on daemon start, on Windows client, the default is
 `hyperv`, and on Windows server, the default is `process`.
 
-#### Daemon DNS options
+### Daemon DNS options
 
 To set the DNS server for all Docker containers, use:
 
@@ -981,7 +981,7 @@ To set the DNS search domain for all Docker containers, use:
 $ sudo dockerd --dns-search example.com
 ```
 
-#### Allow push of nondistributable artifacts
+### Allow push of nondistributable artifacts
 
 Some images (e.g., Windows base images) contain artifacts whose distribution is
 restricted by license. When these images are pushed to a registry, restricted
@@ -1007,7 +1007,7 @@ images without connecting to another server.
 > artifacts to private registries and ensure that you are in compliance with
 > any terms that cover redistributing nondistributable artifacts.
 
-#### Insecure registries
+### Insecure registries
 
 Docker considers a private registry either secure or insecure. In the rest of
 this section, *registry* is used for *private registry*, and `myregistry:5000`
@@ -1051,7 +1051,7 @@ because its use creates security vulnerabilities it should ONLY be enabled for
 testing purposes.  For increased security, users should add their CA to their
 system's list of trusted CAs instead of enabling `--insecure-registry`.
 
-##### Legacy Registries
+#### Legacy Registries
 
 Operations against registries supporting only the legacy v1 protocol are
 disabled by default. Specifically, the daemon will not attempt `push`,
@@ -1066,7 +1066,7 @@ registries that have not yet migrated to the v2 protocol.
 Interaction v1 registries will no longer be supported in Docker v17.12,
 and the `disable-legacy-registry` configuration option will be removed.
 
-#### Running a Docker daemon behind an HTTPS_PROXY
+### Running a Docker daemon behind an HTTPS_PROXY
 
 When running inside a LAN that uses an `HTTPS` proxy, the Docker Hub
 certificates will be replaced by the proxy's certificates. These certificates
@@ -1083,7 +1083,7 @@ This will only add the proxy and authentication to the Docker daemon's requests 
 your `docker build`s and running containers will need extra configuration to
 use the proxy
 
-#### Default `ulimit` settings
+### Default `ulimit` settings
 
 `--default-ulimit` allows you to set the default `ulimit` options to use for
 all containers. It takes the same options as `--ulimit` for `docker run`. If
@@ -1095,7 +1095,7 @@ Be careful setting `nproc` with the `ulimit` flag as `nproc` is designed by Linu
 set the maximum number of processes available to a user, not to a container. For details
 please check the [run](run.md) reference.
 
-#### Node discovery
+### Node discovery
 
 The `--cluster-advertise` option specifies the `host:port` or `interface:port`
 combination that this particular daemon instance should use when advertising
@@ -1130,7 +1130,7 @@ The currently supported cluster store options are:
 | `kv.keyfile`          | Specifies the path to a local file with a PEM encoded private key. This private key is used as the client key for communication with the Key/Value store.                                                                     |
 | `kv.path`             | Specifies the path in the Key/Value store. If not configured, the default value is 'docker/nodes'.                                                                                                                            |
 
-#### Access authorization
+### Access authorization
 
 Docker's access authorization can be extended by authorization plugins that your
 organization can purchase or build themselves. You can install one or more
@@ -1155,7 +1155,7 @@ For information about how to create an authorization plugin, see [authorization
 plugin](../../extend/plugins_authorization.md) section in the Docker extend section of this documentation.
 
 
-#### Daemon user namespace options
+### Daemon user namespace options
 
 The Linux kernel
 [user namespace support](http://man7.org/linux/man-pages/man7/user_namespaces.7.html)
@@ -1237,7 +1237,7 @@ Please note that this feature is still marked as experimental as metrics and met
 names could change while this feature is still in experimental.  Please provide
 feedback on what you would like to see collected in the API.
 
-#### Daemon configuration file
+### Daemon configuration file
 
 The `--config-file` option allows you to set any configuration option
 for the daemon in a JSON format. This file uses the same flag names as keys,

--- a/components/cli/docs/reference/commandline/rmi.md
+++ b/components/cli/docs/reference/commandline/rmi.md
@@ -29,7 +29,7 @@ Options:
 ## Examples
 
 You can remove an image using its short or long ID, its tag, or its digest. If
-an image has one or more tag referencing it, you must remove all of them before
+an image has one or more tags referencing it, you must remove all of them before
 the image is removed. Digest references are removed automatically when an image
 is removed by tag.
 

--- a/components/cli/docs/reference/commandline/service_create.md
+++ b/components/cli/docs/reference/commandline/service_create.md
@@ -294,8 +294,9 @@ volumes in a service:
     <td>
       <p>The type of mount, can be either <tt>volume</tt>, <tt>bind</tt>, or <tt>tmpfs</tt>. Defaults to <tt>volume</tt> if no type is specified.
       <ul>
-        <li><tt>volume</tt>: mounts a [managed volume](volume_create.md) into the container.</li>
-        <li><tt>bind</tt>: bind-mounts a directory or file from the host into the container.</li>
+        <li><tt>volume</tt>: mounts a <a href="https://docs.docker.com/engine/reference/commandline/volume_create/">managed volume</a>
+        into the container.</li> <li><tt>bind</tt>:
+        bind-mounts a directory or file from the host into the container.</li>
         <li><tt>tmpfs</tt>: mount a tmpfs in the container</li>
       </ul></p>
     </td>

--- a/components/cli/docs/reference/commandline/stack_deploy.md
+++ b/components/cli/docs/reference/commandline/stack_deploy.md
@@ -28,6 +28,8 @@ Options:
   -c, --compose-file string   Path to a Compose file
       --help                  Print usage
       --prune                 Prune services that are no longer referenced
+      --resolve-image string  Query the registry to resolve image digest and supported platforms
+                              ("always"|"changed"|"never") (default "always")
       --with-registry-auth    Send registry authentication details to Swarm agents
 ```
 


### PR DESCRIPTION
All cherry-picks went in clean, no conflicts.

https://github.com/docker/cli/pull/610 Update bash completion and deprecation for synchronous service updates

```
$ git cherry-pick -s -x -Xsubtree=components/cli 60bfaba 20d9cec
[d f26232e8f6] Update bash completion for synchronous `docker service` commands
 Author: Harald Albers <github@albersweb.de>
 Date: Sat Oct 7 13:57:26 2017 +0200
 1 file changed, 3 insertions(+), 3 deletions(-)
[d 6fc2c6b8c5] Update deprecation for synchronous service updates
 Author: Harald Albers <github@albersweb.de>
 Date: Sat Oct 7 14:28:56 2017 +0200
 1 file changed, 5 insertions(+), 2 deletions(-)
```

https://github.com/docker/cli/pull/611 Add bash completion for `stack deploy --resolve-image`

```
$ git cherry-pick -s -x -Xsubtree=components/cli 9559b9b
[d b0596beda5] Add bash completion for `stack deploy --resolve-image`
 Author: Harald Albers <github@albersweb.de>
 Date: Mon Oct 9 13:29:17 2017 +0200
 2 files changed, 8 insertions(+), 2 deletions(-)
```

https://github.com/docker/cli/pull/618 Add bash completion for `secret create --driver`

```
$ git cherry-pick -s -x -Xsubtree=components/cli 1d7a31f
[d 550052ebae] Add bash completion for `secret create --driver`
 Author: Harald Albers <github@albersweb.de>
 Date: Wed Oct 11 18:55:28 2017 +0200
 1 file changed, 3 insertions(+), 3 deletions(-)
```

https://github.com/docker/cli/pull/580 Update rmi.md

```
$ git cherry-pick -s -x -Xsubtree=components/cli 9004495
[d 8b13940b3b] Update rmi.md
 Author: djgoosen <djgoosen@users.noreply.github.com>
 Date: Sun Oct 1 21:36:13 2017 -0700
 1 file changed, 1 insertion(+), 1 deletion(-)
```

https://github.com/docker/cli/pull/598 Fix dockerd reference heading levels

```
$ git cherry-pick -s -x -Xsubtree=components/cli aca0421
[d 792e8f9a82] Fix dockerd reference heading levels
 Author: Sebastiaan van Stijn <github@gone.nl>
 Date: Wed Oct 4 18:09:12 2017 +0200
 1 file changed, 10 insertions(+), 10 deletions(-)
```

https://github.com/docker/cli/pull/603 Fix markdown link in service-create reference docs

```
$ git cherry-pick -s -x -Xsubtree=components/cli 6b6511f
[d e7f51b183f] Fix markdown link in service-create reference docs
 Author: Sebastiaan van Stijn <github@gone.nl>
 Date: Thu Oct 5 12:17:40 2017 +0200
 1 file changed, 3 insertions(+), 2 deletions(-)
```