### PR TITLE
[17.10] Add CODEOWNERS File

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# GitHub code owners
+# See https://help.github.com/articles/about-codeowners/
+#
+# KEEP THIS FILE SORTED. Order is important. Last match takes precedence
+
+CHANGELOG.md @mstanleyjones @joaofnfernandes
+components/cli/** @dnephin

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,5 +3,5 @@
 #
 # KEEP THIS FILE SORTED. Order is important. Last match takes precedence
 
-CHANGELOG.md @mstanleyjones @joaofnfernandes
+CHANGELOG.md @mstanleyjones @gbarr01
 components/cli/** @dnephin


### PR DESCRIPTION
Add CODEOWNERS file to auto assign reviewers for CHANGELOG.md and components/cli.

Signed-off-by: Corbin <corbin.coleman@docker.com>