### PR TITLE
[17.11] Add Ubuntu Artful (17.10)

### DIFF
--- a/components/packaging/deb/Makefile
+++ b/components/packaging/deb/Makefile
@@ -61,6 +61,19 @@ ubuntu-zesty: ## build ubuntu zesty deb packages
 		debbuild-$@/$(ARCH)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
 
+.PHONY: ubuntu-artful
+ubuntu-artful: ## build ubuntu artful deb packages
+	docker build -t debbuild-$@/$(ARCH) -f $(CURDIR)/$@/Dockerfile.$(ARCH) .
+	docker run --rm -i \
+		-e VERSION=$(VERSION) \
+		-e DOCKER_GITCOMMIT=$(GITCOMMIT) \
+		-v $(CURDIR)/debbuild/$@:/build \
+		-v $(ENGINE_DIR):/engine \
+		-v $(CLI_DIR):/cli \
+		-v $(CURDIR)/systemd:/root/build-deb/systemd \
+		debbuild-$@/$(ARCH)
+	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
+
 debian-buster: ## build debian buster deb packages
 	docker build -t debbuild-$@/$(ARCH) -f $(CURDIR)/$@/Dockerfile.$(ARCH) .
 	docker run --rm -i \

--- a/components/packaging/deb/ubuntu-artful/Dockerfile.armv7l
+++ b/components/packaging/deb/ubuntu-artful/Dockerfile.armv7l
@@ -2,7 +2,7 @@ FROM arm32v7/ubuntu:artful
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.8.3
+ENV GO_VERSION 1.8.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/components/packaging/deb/ubuntu-artful/Dockerfile.armv7l
+++ b/components/packaging/deb/ubuntu-artful/Dockerfile.armv7l
@@ -1,0 +1,28 @@
+FROM arm32v7/ubuntu:artful
+
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+ENV GO_VERSION 1.8.3
+RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
+ENV RUNC_BUILDTAGS apparmor seccomp selinux
+
+COPY common/ /root/build-deb/debian
+COPY build-deb /root/build-deb/build-deb
+
+RUN mkdir -p /go/src/github.com/docker && \
+	mkdir -p /go/src/github.com/opencontainers && \
+	ln -snf /engine /root/build-deb/engine && \
+	ln -snf /cli /root/build-deb/cli && \
+	ln -snf /root/build-deb/engine /go/src/github.com/docker/docker && \
+	ln -snf /root/build-deb/cli /go/src/github.com/docker/cli
+
+
+ENV DISTRO ubuntu
+ENV SUITE artful
+
+WORKDIR /root/build-deb
+
+ENTRYPOINT ["/root/build-deb/build-deb"]

--- a/components/packaging/deb/ubuntu-artful/Dockerfile.ppc64le
+++ b/components/packaging/deb/ubuntu-artful/Dockerfile.ppc64le
@@ -2,7 +2,7 @@ FROM ppc64le/ubuntu:artful
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev pkg-config vim-common libseccomp-dev libsystemd-dev libltdl-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.8.3
+ENV GO_VERSION 1.8.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:/$GOPATH/bin

--- a/components/packaging/deb/ubuntu-artful/Dockerfile.ppc64le
+++ b/components/packaging/deb/ubuntu-artful/Dockerfile.ppc64le
@@ -1,0 +1,28 @@
+FROM ppc64le/ubuntu:artful
+
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev pkg-config vim-common libseccomp-dev libsystemd-dev libltdl-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+ENV GO_VERSION 1.8.3
+RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" | tar xzC /usr/local
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:/$GOPATH/bin
+ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
+ENV RUNC_BUILDTAGS apparmor seccomp selinux
+
+COPY common/ /root/build-deb/debian
+COPY build-deb /root/build-deb/build-deb
+
+RUN mkdir -p /go/src/github.com/docker && \
+	mkdir -p /go/src/github.com/opencontainers && \
+	ln -snf /engine /root/build-deb/engine && \
+	ln -snf /cli /root/build-deb/cli && \
+	ln -snf /root/build-deb/engine /go/src/github.com/docker/docker && \
+	ln -snf /root/build-deb/cli /go/src/github.com/docker/cli
+
+
+ENV DISTRO ubuntu
+ENV SUITE artful
+
+WORKDIR /root/build-deb
+
+ENTRYPOINT ["/root/build-deb/build-deb"]

--- a/components/packaging/deb/ubuntu-artful/Dockerfile.s390x
+++ b/components/packaging/deb/ubuntu-artful/Dockerfile.s390x
@@ -1,0 +1,28 @@
+FROM s390x/ubuntu:artful
+
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+ENV GO_VERSION 1.8.3
+RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-s390x.tar.gz" | tar xzC /usr/local
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
+ENV RUNC_BUILDTAGS apparmor seccomp selinux
+
+COPY common/ /root/build-deb/debian
+COPY build-deb /root/build-deb/build-deb
+
+RUN mkdir -p /go/src/github.com/docker && \
+	mkdir -p /go/src/github.com/opencontainers && \
+	ln -snf /engine /root/build-deb/engine && \
+	ln -snf /cli /root/build-deb/cli && \
+	ln -snf /root/build-deb/engine /go/src/github.com/docker/docker && \
+	ln -snf /root/build-deb/cli /go/src/github.com/docker/cli
+
+
+ENV DISTRO ubuntu
+ENV SUITE artful
+
+WORKDIR /root/build-deb
+
+ENTRYPOINT ["/root/build-deb/build-deb"]

--- a/components/packaging/deb/ubuntu-artful/Dockerfile.s390x
+++ b/components/packaging/deb/ubuntu-artful/Dockerfile.s390x
@@ -2,7 +2,7 @@ FROM s390x/ubuntu:artful
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.8.3
+ENV GO_VERSION 1.8.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-s390x.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/components/packaging/deb/ubuntu-artful/Dockerfile.x86_64
+++ b/components/packaging/deb/ubuntu-artful/Dockerfile.x86_64
@@ -1,0 +1,28 @@
+FROM ubuntu:artful
+
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+ENV GO_VERSION 1.8.3
+RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
+ENV RUNC_BUILDTAGS apparmor seccomp selinux
+
+COPY common/ /root/build-deb/debian
+COPY build-deb /root/build-deb/build-deb
+
+RUN mkdir -p /go/src/github.com/docker && \
+	mkdir -p /go/src/github.com/opencontainers && \
+	ln -snf /engine /root/build-deb/engine && \
+	ln -snf /cli /root/build-deb/cli && \
+	ln -snf /root/build-deb/engine /go/src/github.com/docker/docker && \
+	ln -snf /root/build-deb/cli /go/src/github.com/docker/cli
+
+
+ENV DISTRO ubuntu
+ENV SUITE artful
+
+WORKDIR /root/build-deb
+
+ENTRYPOINT ["/root/build-deb/build-deb"]

--- a/components/packaging/deb/ubuntu-artful/Dockerfile.x86_64
+++ b/components/packaging/deb/ubuntu-artful/Dockerfile.x86_64
@@ -2,7 +2,7 @@ FROM ubuntu:artful
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.8.3
+ENV GO_VERSION 1.8.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin


### PR DESCRIPTION
Cherry picked from: https://github.com/docker/docker-ce-packaging/pull/55

Cherry pick was **clean**
```
git cherry-pick -s -x -Xsubtree=components/packaging 1468941a50dba7e0a82a01cb938338041f028ef9 c16053e90143cd8a9a559b749407d938f0cb4456
```

Adds support for packaging for Ubuntu Artful (17.10)

Also relates to: https://github.com/docker/for-linux/issues/141