### PR TITLE
[17.11] backport Add containerd static compile

### DIFF
--- a/components/engine/hack/dockerfile/install-binaries.sh
+++ b/components/engine/hack/dockerfile/install-binaries.sh
@@ -34,7 +34,21 @@ install_containerd() {
 	git checkout -q "$CONTAINERD_COMMIT"
 	(
 		export GOPATH
-		make $1
+		make
+	)
+	cp bin/containerd /usr/local/bin/docker-containerd
+	cp bin/containerd-shim /usr/local/bin/docker-containerd-shim
+	cp bin/ctr /usr/local/bin/docker-containerd-ctr
+}
+
+install_containerd_static() {
+	echo "Install containerd version $CONTAINERD_COMMIT"
+	git clone https://github.com/containerd/containerd.git "$GOPATH/src/github.com/containerd/containerd"
+	cd "$GOPATH/src/github.com/containerd/containerd"
+	git checkout -q "$CONTAINERD_COMMIT"
+	(
+		export GOPATH
+		make EXTRA_FLAGS="-buildmode pie" EXTRA_LDFLAGS="-extldflags \\\"-fno-PIC -static\\\""
 	)
 	cp bin/containerd /usr/local/bin/docker-containerd
 	cp bin/containerd-shim /usr/local/bin/docker-containerd-shim
@@ -106,7 +120,7 @@ do
 			;;
 
 		containerd)
-			install_containerd
+			install_containerd_static
 			;;
 
 		containerd-dynamic)


### PR DESCRIPTION
To address:
* https://github.com/moby/moby/issues/35349 containerd binaries no longer static

Backport fix:
* https://github.com/moby/moby/pull/35350 Add containerd static compile

With cherry-pick of git commit https://github.com/moby/moby/pull/35350/commits/007db06:
```
$ git cherry-pick -s -x -Xsubtree=components/engine 007db06
```

cherry-pick went in clean