### PR TITLE
[17.11]  cluster: avoid recursive readlock on swarm info

### DIFF
--- a/components/engine/daemon/cluster/swarm.go
+++ b/components/engine/daemon/cluster/swarm.go
@@ -198,9 +198,9 @@ func (c *Cluster) Join(req types.JoinRequest) error {
 
 // Inspect retrieves the configuration properties of a managed swarm cluster.
 func (c *Cluster) Inspect() (types.Swarm, error) {
-	var swarm *swarmapi.Cluster
+	var swarm types.Swarm
 	if err := c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
-		s, err := getSwarm(ctx, state.controlClient)
+		s, err := c.inspect(ctx, state)
 		if err != nil {
 			return err
 		}
@@ -209,7 +209,15 @@ func (c *Cluster) Inspect() (types.Swarm, error) {
 	}); err != nil {
 		return types.Swarm{}, err
 	}
-	return convert.SwarmFromGRPC(*swarm), nil
+	return swarm, nil
+}
+
+func (c *Cluster) inspect(ctx context.Context, state nodeState) (types.Swarm, error) {
+	s, err := getSwarm(ctx, state.controlClient)
+	if err != nil {
+		return types.Swarm{}, err
+	}
+	return convert.SwarmFromGRPC(*s), nil
 }
 
 // Update updates configuration of a managed swarm cluster.
@@ -413,7 +421,7 @@ func (c *Cluster) Info() types.Info {
 
 	if state.IsActiveManager() {
 		info.ControlAvailable = true
-		swarm, err := c.Inspect()
+		swarm, err := c.inspect(ctx, state)
 		if err != nil {
 			info.Error = err.Error()
 		}


### PR DESCRIPTION
backport:
* moby/moby#35388 cluster: avoid recursive readlock on swarm info

with cherry-pick of git commit https://github.com/moby/moby/pull/35388/commits/ee1be71:
```
$ git cherry-pick -s -x -Xsubtree=components/engine ee1be71
```

no conflicts