### PR TITLE
[17.11] Add /proc/scsi to masked paths

### DIFF
--- a/components/engine/oci/defaults.go
+++ b/components/engine/oci/defaults.go
@@ -119,6 +119,7 @@ func DefaultLinuxSpec() specs.Spec {
 			"/proc/timer_list",
 			"/proc/timer_stats",
 			"/proc/sched_debug",
+			"/proc/scsi",
 		},
 		ReadonlyPaths: []string{
 			"/proc/asound",


### PR DESCRIPTION
Backport of https://github.com/moby/moby/pull/35399 for Docker 17.11

    git cherry-pick -s -S -x -Xsubtree=components/engine a21ecdf3c8a343a7c94e4c4d01b178c87ca7aaa1

This is writeable, and can be used to remove devices. Containers do
not need to know about scsi devices.

(cherry picked from commit a21ecdf3c8a343a7c94e4c4d01b178c87ca7aaa1)