### PR TITLE
[17.11] builder: fix long stream sync

### DIFF
--- a/components/engine/builder/dockerfile/builder.go
+++ b/components/engine/builder/dockerfile/builder.go
@@ -131,10 +131,10 @@ func (bm *BuildManager) initializeClientSession(ctx context.Context, cancel func
 	}
 	logrus.Debug("client is session enabled")
 
-	ctx, cancelCtx := context.WithTimeout(ctx, sessionConnectTimeout)
+	connectCtx, cancelCtx := context.WithTimeout(ctx, sessionConnectTimeout)
 	defer cancelCtx()
 
-	c, err := bm.sg.Get(ctx, options.SessionID)
+	c, err := bm.sg.Get(connectCtx, options.SessionID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Backport of https://github.com/moby/moby/issues/35391 for 17.11  (addresses https://github.com/moby/moby/issues/35391 for 17.11)

    git cherry-pick -s -S -x -Xsubtree=components/engine c6703b722e1c0914342d61ca6af77aea93150873



(cherry picked from commit c6703b722e1c0914342d61ca6af77aea93150873)

ping @tonistiigi @andrewhsu 
