### PR TITLE
[17.11] Set OS on scratch image and prevent panic if empty

### DIFF
--- a/components/engine/builder/dockerfile/imagecontext.go
+++ b/components/engine/builder/dockerfile/imagecontext.go
@@ -1,6 +1,8 @@
 package dockerfile
 
 import (
+	"runtime"
+
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/builder/remotecontext"
@@ -73,7 +75,13 @@ func (m *imageSources) Unmount() (retErr error) {
 func (m *imageSources) Add(im *imageMount) {
 	switch im.image {
 	case nil:
-		im.image = &dockerimage.Image{}
+		// set the OS for scratch images
+		os := runtime.GOOS
+		// Windows does not support scratch except for LCOW
+		if runtime.GOOS == "windows" {
+			os = "linux"
+		}
+		im.image = &dockerimage.Image{V1Image: dockerimage.V1Image{OS: os}}
 	default:
 		m.byImageID[im.image.ImageID()] = im
 	}

--- a/components/engine/daemon/create.go
+++ b/components/engine/daemon/create.go
@@ -95,7 +95,14 @@ func (daemon *Daemon) create(params types.ContainerCreateConfig, managed bool) (
 		if err != nil {
 			return nil, err
 		}
-		os = img.OS
+		if img.OS != "" {
+			os = img.OS
+		} else {
+			// default to the host OS except on Windows with LCOW
+			if runtime.GOOS == "windows" && system.LCOWSupported() {
+				os = "linux"
+			}
+		}
 		imgID = img.ID()
 
 		if runtime.GOOS == "windows" && img.OS == "linux" && !system.LCOWSupported() {


### PR DESCRIPTION
backport:
* https://github.com/moby/moby/pull/35419 Set OS on scratch image and prevent panic if empty

with cherry-pick of https://github.com/moby/moby/pull/35419/commits/a97817b673cbd3bfaf6e752282c4992ac43ff594:
```
$ git cherry-pick -s -x -Xsubtree=components/engine a97817b
[scra c2888f5973] Set OS on scratch image and prevent panic if empty
 Author: John Stephens <johnstep@docker.com>
 Date: Mon Nov 6 18:21:10 2017 -0800
 3 files changed, 39 insertions(+), 2 deletions(-)
```

clean cherry-pick