### PR TITLE
[17.11] vendor: update to github.com/vbatts/tar-split@v0.10.2

### DIFF
--- a/components/engine/integration/image/import_test.go
+++ b/components/engine/integration/image/import_test.go
@@ -1,0 +1,36 @@
+package image
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/integration/util/request"
+	"github.com/docker/docker/internal/testutil"
+)
+
+// Ensure we don't regress on CVE-2017-14992.
+func TestImportExtremelyLargeImageWorks(t *testing.T) {
+	client := request.NewAPIClient(t)
+
+	// Construct an empty tar archive with about 8GB of junk padding at the
+	// end. This should not cause any crashes (the padding should be mostly
+	// ignored).
+	var tarBuffer bytes.Buffer
+	tw := tar.NewWriter(&tarBuffer)
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	imageRdr := io.MultiReader(&tarBuffer, io.LimitReader(testutil.DevZero, 8*1024*1024*1024))
+
+	_, err := client.ImageImport(context.Background(),
+		types.ImageImportSource{Source: imageRdr, SourceName: "-"},
+		"test1234:v42",
+		types.ImageImportOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/components/engine/internal/testutil/helpers.go
+++ b/components/engine/internal/testutil/helpers.go
@@ -1,6 +1,8 @@
 package testutil
 
 import (
+	"io"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -10,4 +12,16 @@ import (
 func ErrorContains(t require.TestingT, err error, expectedError string, msgAndArgs ...interface{}) {
 	require.Error(t, err, msgAndArgs...)
 	assert.Contains(t, err.Error(), expectedError, msgAndArgs...)
+}
+
+// DevZero acts like /dev/zero but in an OS-independent fashion.
+var DevZero io.Reader = devZero{}
+
+type devZero struct{}
+
+func (d devZero) Read(p []byte) (n int, err error) {
+	for i := 0; i < len(p); i++ {
+		p[i] = '\x00'
+	}
+	return len(p), nil
 }

--- a/components/engine/vendor.conf
+++ b/components/engine/vendor.conf
@@ -55,7 +55,7 @@ github.com/miekg/dns 75e6e86cc601825c5dbcd4e0c209eab180997cd7
 
 # get graph and distribution packages
 github.com/docker/distribution edc3ab29cdff8694dd6feb85cfeb4b5f1b38ed9c
-github.com/vbatts/tar-split v0.10.1
+github.com/vbatts/tar-split v0.10.2
 github.com/opencontainers/go-digest a6d0ee40d4207ea02364bd3b9e8e77b9159ba1eb
 
 # get go-zfs packages

--- a/components/engine/vendor/github.com/vbatts/tar-split/README.md
+++ b/components/engine/vendor/github.com/vbatts/tar-split/README.md
@@ -1,6 +1,7 @@
 # tar-split
 
 [![Build Status](https://travis-ci.org/vbatts/tar-split.svg?branch=master)](https://travis-ci.org/vbatts/tar-split)
+[![Go Report Card](https://goreportcard.com/badge/github.com/vbatts/tar-split)](https://goreportcard.com/report/github.com/vbatts/tar-split)
 
 Pristinely disassembling a tar archive, and stashing needed raw bytes and offsets to reassemble a validating original archive.
 
@@ -50,7 +51,7 @@ For example stored sparse files that have "holes" in them, will be read as a
 contiguous file, though the archive contents may be recorded in sparse format.
 Therefore when adding the file payload to a reassembled tar, to achieve
 identical output, the file payload would need be precisely re-sparsified. This
-is not something I seek to fix imediately, but would rather have an alert that
+is not something I seek to fix immediately, but would rather have an alert that
 precise reassembly is not possible.
 (see more http://www.gnu.org/software/tar/manual/html_node/Sparse-Formats.html)
 


### PR DESCRIPTION
backport:
* https://github.com/moby/moby/pull/35424 vendor: update to github.com/vbatts/tar-split@v0.10.2

with cherry-pick of https://github.com/moby/moby/pull/35424/commits/e0ff7cc https://github.com/moby/moby/pull/35424/commits/2f8d3e1 https://github.com/moby/moby/pull/35424/commits/0a13f82
```
$ git cherry-pick -s -x -Xsubtree=components/engine e0ff7cc 2f8d3e1 0a13f82
[tar b25cbcb9af] vendor: update to github.com/vbatts/tar-split@v0.10.2
 Author: Aleksa Sarai <asarai@suse.de>
 Date: Wed Nov 8 02:50:52 2017 +1100
 3 files changed, 31 insertions(+), 17 deletions(-)
[tar 4cd44b4bf2] internal: testutil: add DevZero helper
 Author: Aleksa Sarai <asarai@suse.de>
 Date: Wed Nov 8 03:29:49 2017 +1100
 1 file changed, 14 insertions(+)
[tar ff01ab4a0a] image: add import test for CVE-2017-14992
 Author: Aleksa Sarai <asarai@suse.de>
 Date: Wed Nov 8 03:30:47 2017 +1100
 1 file changed, 36 insertions(+)
 create mode 100644 components/engine/integration/image/import_test.go
```

clean cherry-pick