### PR TITLE
[17.09] Fix conflicting container name producint 400 error instead of 409

### DIFF
--- a/components/engine/daemon/errors.go
+++ b/components/engine/daemon/errors.go
@@ -64,6 +64,17 @@ func errExecPaused(id string) error {
 	return stateConflictError{cause}
 }
 
+type nameConflictError struct {
+	id   string
+	name string
+}
+
+func (e nameConflictError) Error() string {
+	return fmt.Sprintf("Conflict. The container name %q is already in use by container %q. You have to remove (or rename) that container to be able to reuse that name.", e.name, e.id)
+}
+
+func (nameConflictError) Conflict() {}
+
 type validationError struct {
 	cause error
 }

--- a/components/engine/daemon/names.go
+++ b/components/engine/daemon/names.go
@@ -69,7 +69,7 @@ func (daemon *Daemon) reserveName(id, name string) (string, error) {
 				logrus.Errorf("got unexpected error while looking up reserved name: %v", err)
 				return "", err
 			}
-			return "", validationError{errors.Errorf("Conflict. The container name %q is already in use by container %q. You have to remove (or rename) that container to be able to reuse that name.", name, id)}
+			return "", nameConflictError{id: id, name: name}
 		}
 		return "", errors.Wrapf(err, "error reserving name: %q", name)
 	}


### PR DESCRIPTION
Backport of https://github.com/moby/moby/pull/35022/commits/e424343b4348f994d5c2922e7556629a620b4b3b (https://github.com/moby/moby/pull/35022) for Docker CE 17.09

(cherry picked from commit e424343b4348f994d5c2922e7556629a620b4b3b)



Commit ebcb7d6b406fe50ea9a237c73004d75884184c33 removed string checking
for error messages, in favor of typed errors.

In this change, the status code for conflicting container  names
changed from 409 to 400 (validationError).

This patch add a `nameConflictError`, changing the status code to
409 as it was in older versions.

With this change applied, the correct 409 status is returned:

```bash
$ docker create --name c1 busybox
```

```bash
$ curl --unix-socket /var/run/docker.sock -v -XPOST -H"Content-Type: application/json" -d'{"Image":"busybox"}' http://localhost/containers/create?name=c1
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying /var/run/docker.sock...
* Connected to localhost (/var/run/docker.sock) port 80 (#0)
> POST /containers/create?name=c1 HTTP/1.1
> Host: localhost
> User-Agent: curl/7.52.1
> Accept: */*
> Content-Type: application/json
> Content-Length: 19
>
* upload completely sent off: 19 out of 19 bytes
< HTTP/1.1 409 Conflict
< Api-Version: 1.33
< Content-Type: application/json
< Docker-Experimental: false
< Ostype: linux
< Server: Docker/17.06.0-dev (linux)
< Date: Thu, 28 Sep 2017 15:07:23 GMT
< Content-Length: 229
<
{"message":"Conflict. The container name \"/c1\" is already in use by container \"ed2efdc806c1883954e677eb9ab8cbc7e286c9c5934ef6724fd5d93c56744923\". You have to remove (or rename) that container to be able to reuse that name."}
* Curl_http_done: called premature == 0
* Connection #0 to host localhost left intact
```

