### PR TITLE
[17.09] Use rslave instead of rprivate in chrootarchive

### DIFF
--- a/components/engine/pkg/chrootarchive/chroot_linux.go
+++ b/components/engine/pkg/chrootarchive/chroot_linux.go
@@ -26,8 +26,13 @@ func chroot(path string) (err error) {
 		return fmt.Errorf("Error creating mount namespace before pivot: %v", err)
 	}
 
-	// make everything in new ns private
-	if err := mount.MakeRPrivate("/"); err != nil {
+	// Make everything in new ns slave.
+	// Don't use `private` here as this could race where the mountns gets a
+	//   reference to a mount and an unmount from the host does not propagate,
+	//   which could potentially cause transient errors for other operations,
+	//   even though this should be relatively small window here `slave` should
+	//   not cause any problems.
+	if err := mount.MakeRSlave("/"); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/35217 for 17.09
(cherry picked from commit 5ede64d63fec0b9d4cf921b6f8fb946e65287538)

With `rprivate` there exists a race where a reference to a mount has
propagated to the new namespace, when `rprivate` is set the parent
namespace is not able to remove the mount due to that reference.
With `rslave` unmounts will propagate correctly into the namespace and
prevent the sort of transient errors that are possible with `rprivate`.

This is a similar fix to https://github.com/opencontainers/runc/pull/1500/commits/117c92745bd098bf05a69489b7b78cac6364e1d0


ping @cpuguy83 @kolyshkin 