### PR TITLE
[17.09] Warn on empty continuation lines only, not for comments

### DIFF
--- a/components/engine/builder/dockerfile/parser/parser.go
+++ b/components/engine/builder/dockerfile/parser/parser.go
@@ -290,6 +290,10 @@ func Parse(rwc io.Reader) (*Result, error) {
 			}
 			currentLine++
 
+			if isComment(scanner.Bytes()) {
+				// original line was a comment (processLine strips comments)
+				continue
+			}
 			if isEmptyContinuationLine(bytesRead) {
 				hasEmptyContinuationLine = true
 				continue
@@ -331,8 +335,12 @@ func trimWhitespace(src []byte) []byte {
 	return bytes.TrimLeftFunc(src, unicode.IsSpace)
 }
 
+func isComment(line []byte) bool {
+	return tokenComment.Match(trimWhitespace(line))
+}
+
 func isEmptyContinuationLine(line []byte) bool {
-	return len(trimComments(trimWhitespace(line))) == 0
+	return len(trimWhitespace(line)) == 0
 }
 
 var utf8bom = []byte{0xEF, 0xBB, 0xBF}

--- a/components/engine/builder/dockerfile/parser/parser_test.go
+++ b/components/engine/builder/dockerfile/parser/parser_test.go
@@ -141,6 +141,13 @@ RUN something \
 RUN another \
 
     thing
+RUN non-indented \
+# this is a comment
+   after-comment
+
+RUN indented \
+    # this is an indented comment
+    comment
 	`)
 
 	result, err := Parse(dockerfile)


### PR DESCRIPTION
back port of https://github.com/moby/moby/pull/35004 for 17.09

(cherry picked from commit 2fd736ac10c1c46d1001373d887cb99b3d8ee824)

Commit 8d1ae76dcbbb73d8e20c6a14a7d3fe2410b95f55 added
deprecation warnings for empty continuation lines,
but also treated comment-only lines as empty.

This patch distinguishes empty continuation lines
from comment-only lines, and only outputs warnings
for the former.
