### PR TITLE
[17.09] Don't abort when setting may_detach_mounts

### DIFF
--- a/components/engine/daemon/daemon_unix.go
+++ b/components/engine/daemon/daemon_unix.go
@@ -1298,7 +1298,10 @@ func setupDaemonProcess(config *config.Config) error {
 	if err := setupOOMScoreAdj(config.OOMScoreAdjust); err != nil {
 		return err
 	}
-	return setMayDetachMounts()
+	if err := setMayDetachMounts(); err != nil {
+		logrus.WithError(err).Warn("Could not set may_detach_mounts kernel parameter")
+	}
+	return nil
 }
 
 // This is used to allow removal of mountpoints that may be mounted in other


### PR DESCRIPTION
back port of https://github.com/moby/moby/pull/35172 for 17.09 

(cherry picked from commit c6a2044497e0e1ff61350859c8572a2c31c17ced)


83c2152de503012195bd26069fd8fbd2dea4b32f sets the kernel param for
fs.may_detach_mounts, but this is not neccessary for the daemon to
operate. Instead of erroring out (and thus aborting startup) just log
the error.


ping @cpuguy83 PTAL