### PR TITLE
[17.09] Fix honoring tmpfs-size for user /dev/shm mount

### DIFF
--- a/components/engine/daemon/daemon_linux_test.go
+++ b/components/engine/daemon/daemon_linux_test.go
@@ -5,6 +5,13 @@ package daemon
 import (
 	"strings"
 	"testing"
+
+	containertypes "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/container"
+	"github.com/docker/docker/oci"
+	"github.com/docker/docker/pkg/idtools"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const mountsFixture = `142 78 0:38 / / rw,relatime - aufs none rw,si=573b861da0b3a05b,dio
@@ -100,5 +107,53 @@ func TestNotCleanupMounts(t *testing.T) {
 	d.cleanupMountsFromReaderByID(strings.NewReader(mountInfo), "", unmount)
 	if unmounted {
 		t.Fatal("Expected not to clean up /dev/shm")
+	}
+}
+
+// TestTmpfsDevShmSizeOverride checks that user-specified /dev/tmpfs mount
+// size is not overriden by the default shmsize (that should only be used
+// for default /dev/shm (as in "shareable" and "private" ipc modes).
+// https://github.com/moby/moby/issues/35271
+func TestTmpfsDevShmSizeOverride(t *testing.T) {
+	size := "777m"
+	mnt := "/dev/shm"
+
+	d := Daemon{
+		idMappings: &idtools.IDMappings{},
+	}
+	c := &container.Container{
+		HostConfig: &containertypes.HostConfig{
+			ShmSize: 48 * 1024, // size we should NOT end up with
+		},
+	}
+	ms := []container.Mount{
+		{
+			Source:      "tmpfs",
+			Destination: mnt,
+			Data:        "size=" + size,
+		},
+	}
+
+	// convert ms to spec
+	spec := oci.DefaultSpec()
+	err := setMounts(&d, &spec, c, ms)
+	assert.NoError(t, err)
+
+	// Check the resulting spec for the correct size
+	found := false
+	for _, m := range spec.Mounts {
+		if m.Destination == mnt {
+			for _, o := range m.Options {
+				if !strings.HasPrefix(o, "size=") {
+					continue
+				}
+				t.Logf("%+v\n", m.Options)
+				assert.Equal(t, "size="+size, o)
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatal("/dev/shm not found in spec, or size option missing")
 	}
 }


### PR DESCRIPTION
Backport of 
 - https://github.com/moby/moby/pull/35316 Fix honoring tmpfs-size for user /dev/shm mount

```
$ git checkout 17.09
Branch 17.09 set up to track remote branch 17.09 from origin.
Switched to a new branch '17.09'
$ git checkout -b backport-353516-17.09
Switched to a new branch 'backport-353516-17.09'
$ git cherry-pick -s -x -Xsubtree=components/engine  31d30a985d99a0eef 2e0a98b605fa27
error: could not apply 31d30a985d... Fix user mount /dev/shm size
hint: after resolving the conflicts, mark the corrected paths
hint: with 'git add <paths>' or 'git rm <paths>'
hint: and commit the result with 'git commit'
$ vim components/engine/daemon/oci_linux.go
$ git add components/engine/daemon/oci_linux.go
$ git cherry-pick --continue 
[backport-353516-17.09 15e5af3a07] Fix user mount /dev/shm size
 Date: Fri Oct 27 00:21:41 2017 -0700
 1 file changed, 21 insertions(+), 16 deletions(-)
[backport-353516-17.09 3406769872] integration: test case for #35271
 Date: Sun Nov 12 18:27:05 2017 -0800
 1 file changed, 55 insertions(+)
```
I had to fix the patch because a single comment line which interfered with the patch was added by https://github.com/moby/moby/commit/e89b6e8c2d2c36c4#diff-ea22bb26655e758dc94c291dbaee0e76