### PR TITLE
[17.09] Backport version fix for Windows manifest lists

### DIFF
--- a/components/engine/distribution/pull_v2.go
+++ b/components/engine/distribution/pull_v2.go
@@ -708,28 +708,19 @@ func (p *v2Puller) pullManifestList(ctx context.Context, ref reference.Named, mf
 	}
 
 	logrus.Debugf("%s resolved to a manifestList object with %d entries; looking for a os/arch match", ref, len(mfstList.Manifests))
-	var manifestDigest digest.Digest
-	// TODO @jhowardmsft LCOW Support: Need to remove the hard coding in LCOW mode.
-	lookingForOS := runtime.GOOS
-	if system.LCOWSupported() {
-		lookingForOS = "linux"
-	}
-	for _, manifestDescriptor := range mfstList.Manifests {
-		// TODO(aaronl): The manifest list spec supports optional
-		// "features" and "variant" fields. These are not yet used.
-		// Once they are, their values should be interpreted here.
-		if manifestDescriptor.Platform.Architecture == runtime.GOARCH && manifestDescriptor.Platform.OS == lookingForOS {
-			manifestDigest = manifestDescriptor.Digest
-			logrus.Debugf("found match for %s/%s with media type %s, digest %s", runtime.GOOS, runtime.GOARCH, manifestDescriptor.MediaType, manifestDigest.String())
-			break
-		}
-	}
 
-	if manifestDigest == "" {
+	manifestMatches := filterManifests(mfstList.Manifests)
+
+	if len(manifestMatches) == 0 {
 		errMsg := fmt.Sprintf("no matching manifest for %s/%s in the manifest list entries", runtime.GOOS, runtime.GOARCH)
 		logrus.Debugf(errMsg)
 		return "", "", errors.New(errMsg)
 	}
+
+	if len(manifestMatches) > 1 {
+		logrus.Debugf("found multiple matches in manifest list, choosing best match %s", manifestMatches[0].Digest.String())
+	}
+	manifestDigest := manifestMatches[0].Digest
 
 	manSvc, err := p.repo.Manifests(ctx)
 	if err != nil {

--- a/components/engine/distribution/pull_v2_unix.go
+++ b/components/engine/distribution/pull_v2_unix.go
@@ -3,11 +3,27 @@
 package distribution
 
 import (
+	"runtime"
+
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/manifest/manifestlist"
+	"github.com/sirupsen/logrus"
 )
 
 func (ld *v2LayerDescriptor) open(ctx context.Context) (distribution.ReadSeekCloser, error) {
 	blobs := ld.repo.Blobs(ctx)
 	return blobs.Open(ctx, ld.digest)
+}
+
+func filterManifests(manifests []manifestlist.ManifestDescriptor) []manifestlist.ManifestDescriptor {
+	var matches []manifestlist.ManifestDescriptor
+	for _, manifestDescriptor := range manifests {
+		if manifestDescriptor.Platform.Architecture == runtime.GOARCH && manifestDescriptor.Platform.OS == runtime.GOOS {
+			matches = append(matches, manifestDescriptor)
+
+			logrus.Debugf("found match for %s/%s with media type %s, digest %s", runtime.GOOS, runtime.GOARCH, manifestDescriptor.MediaType, manifestDescriptor.Digest.String())
+		}
+	}
+	return matches
 }

--- a/components/engine/distribution/pull_v2_windows.go
+++ b/components/engine/distribution/pull_v2_windows.go
@@ -75,43 +75,40 @@ func filterManifests(manifests []manifestlist.ManifestDescriptor) []manifestlist
 
 	var matches []manifestlist.ManifestDescriptor
 	for _, manifestDescriptor := range manifests {
+		// TODO: Consider filtering out greater versions, including only greater UBR
 		if manifestDescriptor.Platform.Architecture == runtime.GOARCH && manifestDescriptor.Platform.OS == lookingForOS {
-			if !versionMatch(manifestDescriptor.Platform.OSVersion, osVersion) {
-				continue
-			}
 			matches = append(matches, manifestDescriptor)
 
 			logrus.Debugf("found match for %s/%s with media type %s, digest %s", runtime.GOOS, runtime.GOARCH, manifestDescriptor.MediaType, manifestDescriptor.Digest.String())
 		}
 	}
-	sort.Stable(manifestsByVersion(matches))
+	if lookingForOS == "windows" {
+		sort.Stable(manifestsByVersion{osVersion, matches})
+	}
 	return matches
 }
 
 func versionMatch(actual, expected string) bool {
-	// Check whether actual and expected are equivalent, or whether
-	// expected is a version prefix of actual.
-	return actual == "" || expected == "" || actual == expected || strings.HasPrefix(actual, expected+".")
+	// Check whether the version matches up to the build, ignoring UBR
+	return strings.HasPrefix(actual, expected+".")
 }
 
-type manifestsByVersion []manifestlist.ManifestDescriptor
+type manifestsByVersion struct {
+	version string
+	list    []manifestlist.ManifestDescriptor
+}
 
 func (mbv manifestsByVersion) Less(i, j int) bool {
-	if mbv[i].Platform.OSVersion == "" {
-		return false
-	}
-	if mbv[j].Platform.OSVersion == "" {
-		return true
-	}
 	// TODO: Split version by parts and compare
 	// TODO: Prefer versions which have a greater version number
-	return false
+	// Move compatible versions to the top, with no other ordering changes
+	return versionMatch(mbv.list[i].Platform.OSVersion, mbv.version) && !versionMatch(mbv.list[j].Platform.OSVersion, mbv.version)
 }
 
 func (mbv manifestsByVersion) Len() int {
-	return len(mbv)
+	return len(mbv.list)
 }
 
 func (mbv manifestsByVersion) Swap(i, j int) {
-	mbv[i], mbv[j] = mbv[j], mbv[i]
+	mbv.list[i], mbv.list[j] = mbv.list[j], mbv.list[i]
 }


### PR DESCRIPTION
Backport fix:

- https://github.com/moby/moby/pull/35090
- https://github.com/moby/moby/pull/35117

with cherry pick of https://github.com/moby/moby/commit/38aef56e1fcb8ea318df98c89cf002267b88a136 and https://github.com/moby/moby/commit/8ed8f4a71d7e1a936fa077b4348b7375c81746a6:

```
git cherry-pick -s -x -Xsubtree=components/engine 38aef5
git cherry-pick -s -x -Xsubtree=components/engine 8ed8f4
```

Conflict with `pull_v2_windows.go` in https://github.com/moby/moby/commit/8ed8f4a71d7e1a936fa077b4348b7375c81746a6 resolved by reverting back to detecting the OS the previous way (before it was supplied as a parameter).