### PR TITLE
[17.09] Avoid failing the test if container is already stopped

### DIFF
--- a/components/engine/integration-cli/docker_cli_events_unix_test.go
+++ b/components/engine/integration-cli/docker_cli_events_unix_test.go
@@ -97,7 +97,7 @@ func (s *DockerSuite) TestEventsOOMDisableTrue(c *check.C) {
 	}()
 
 	c.Assert(waitRun("oomTrue"), checker.IsNil)
-	defer dockerCmd(c, "kill", "oomTrue")
+	defer dockerCmdWithResult("kill", "oomTrue")
 	containerID := inspectField(c, "oomTrue", "Id")
 
 	testActions := map[string]chan bool{


### PR DESCRIPTION
seeing lots of [failures](https://jenkins.dockerproject.org/job/docker-ce-pr-s390x/173/execution/node/243/log/?consoleFull) on s390x even though the same test passes for x86_64 and ppc64le:
```
FAIL: docker_cli_events_unix_test.go:81: DockerSuite.TestEventsOOMDisableTrue

docker_cli_events_unix_test.go:126:
    ...
/go/src/github.com/docker/docker/vendor/github.com/gotestyourself/gotestyourself/icmd/command.go:61:
    t.Fatalf("at %s:%d - %s\n", filepath.Base(file), line, err.Error())
... Error: at cli.go:33 - 
Command:  /usr/local/cli/docker kill oomTrue
ExitCode: 1
Error:    exit status 1
Stdout:   
Stderr:   Error response from daemon: Cannot kill container: oomTrue: Container 4979020323f1a54da9f08c5b40c276b9ffcfe982722f5f2432f591af630a2c73 is not running


Failures:
ExitCode was 1 expected 0
Expected no error
```

this PR backports a fix for flakiness on that test:
* moby/moby#34730 Events CLI tests: fix flakyness of TestEventsOOMDisableTrue

with cherry-pick of git commit https://github.com/moby/moby/pull/34730/commits/adf75503dba2e782139173c011999eacd0c3d7e2:
```
$ git cherry-pick -s -x -Xsubtree=components/engine adf7550
```

no conflicts