### PR TITLE
[17.09] Fix version comparison when negotiating the the API version

### DIFF
--- a/components/cli/vendor.conf
+++ b/components/cli/vendor.conf
@@ -4,7 +4,9 @@ github.com/coreos/etcd 824277cb3a577a0e8c829ca9ec557b973fe06d20
 github.com/cpuguy83/go-md2man a65d4d2de4d5f7c74868dfa9b202a3c8be315aaa
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
 github.com/docker/distribution edc3ab29cdff8694dd6feb85cfeb4b5f1b38ed9c
-github.com/docker/docker 84144a8c66c1bb2af8fa997288f51ef2719971b4
+
+# github.com/docker/docker has https://github.com/moby/moby/pull/35008/commits/4b6ec10b07c14e7fff1cc51156b6d954147f826f applied
+#github.com/docker/docker 84144a8c66c1bb2af8fa997288f51ef2719971b4
 github.com/docker/docker-credential-helpers v0.5.1
 
 # the docker/go package contains a customized version of canonical/json

--- a/components/cli/vendor/github.com/docker/docker/client/client.go
+++ b/components/cli/vendor/github.com/docker/docker/client/client.go
@@ -248,8 +248,8 @@ func (cli *Client) NegotiateAPIVersionPing(p types.Ping) {
 		cli.version = api.DefaultVersion
 	}
 
-	// if server version is lower than the maximum version supported by the Client, downgrade
-	if versions.LessThan(p.APIVersion, api.DefaultVersion) {
+	// if server version is lower than the client version, downgrade
+	if versions.LessThan(p.APIVersion, cli.version) {
 		cli.version = p.APIVersion
 	}
 }

--- a/components/engine/client/client.go
+++ b/components/engine/client/client.go
@@ -266,8 +266,8 @@ func (cli *Client) NegotiateAPIVersionPing(p types.Ping) {
 		cli.version = api.DefaultVersion
 	}
 
-	// if server version is lower than the maximum version supported by the Client, downgrade
-	if versions.LessThan(p.APIVersion, api.DefaultVersion) {
+	// if server version is lower than the client version, downgrade
+	if versions.LessThan(p.APIVersion, cli.version) {
 		cli.version = p.APIVersion
 	}
 }

--- a/components/engine/client/client_test.go
+++ b/components/engine/client/client_test.go
@@ -245,6 +245,14 @@ func TestNegotiateAPIVersion(t *testing.T) {
 	// test downgrade
 	client.NegotiateAPIVersionPing(ping)
 	assert.Equal(t, expected, client.version)
+
+	// set the client version to something older, and verify that we keep the
+	// original setting.
+	expected = "1.20"
+	client.version = expected
+	client.NegotiateAPIVersionPing(ping)
+	assert.Equal(t, expected, client.version)
+
 }
 
 // TestNegotiateAPIVersionOverride asserts that we honor


### PR DESCRIPTION
Cherry-pick of https://github.com/moby/moby/pull/35008 (https://github.com/moby/moby/pull/35008/commits/4b6ec10b07c14e7fff1cc51156b6d954147f826f) into components/engine and components/cli;

```bash
git fetch https://github.com/moby/moby.git master:moby-master
git fetch https://github.com/docker/cli.git master:cli-master

git checkout -b 17.09-backport-cli-version upstream/17.09

git cherry-pick -s -S -x -Xsubtree=components/engine 4b6ec10b07c14e7fff1cc51156b6d954147f826f

git format-patch -1 4b6ec10b07c14e7fff1cc51156b6d954147f826f
0001-Fix-version-comparison-when-negotiating-the-the-API-.patch

git am -s -S \
  --directory=components/cli/vendor/github.com/docker/docker \
  --exclude=components/cli/vendor/github.com/docker/docker/client/client_test.go \
  0001-Fix-version-comparison-when-negotiating-the-the-API-.patch
```
