### PR TITLE
[17.09] backport logentry fixes

### DIFF
--- a/components/engine/daemon/logger/logentries/logentries.go
+++ b/components/engine/daemon/logger/logentries/logentries.go
@@ -50,8 +50,10 @@ func New(info logger.Info) (logger.Logger, error) {
 		return nil, errors.Wrap(err, "error connecting to logentries")
 	}
 	var lineOnly bool
-	if lineOnly, err = strconv.ParseBool(info.Config[lineonly]); err != nil {
-		return nil, errors.Wrap(err, "error parsing lineonly option")
+	if info.Config[lineonly] != "" {
+		if lineOnly, err = strconv.ParseBool(info.Config[lineonly]); err != nil {
+			return nil, errors.Wrap(err, "error parsing lineonly option")
+		}
 	}
 	return &logentries{
 		containerID:   info.ContainerID,

--- a/components/engine/daemon/logger/logentries/logentries.go
+++ b/components/engine/daemon/logger/logentries/logentries.go
@@ -76,7 +76,7 @@ func (f *logentries) Log(msg *logger.Message) error {
 		logger.PutMessage(msg)
 		f.writer.Println(f.tag, ts, data)
 	} else {
-		line := msg.Line
+		line := string(msg.Line)
 		logger.PutMessage(msg)
 		f.writer.Println(line)
 	}


### PR DESCRIPTION
Cherry-picks for 17.09.1 of:

- https://github.com/moby/moby/pull/35612 - Logentries driver line-only=true []byte output fix
- https://github.com/moby/moby/pull/35628 - Logentries line-only logopt fix to maintain backwards compatibility


```
git checkout -b 17.09-backport-logentry-fixes upstream/17.09
git cherry-pick -s -S -x -Xsubtree=components/engine 440e50b6c702b5e13fff9424ef656b6bb6a259f0
git cherry-pick -s -S -x -Xsubtree=components/engine 27a5b878c149fd70ca1e0beebda58edcc19abc73
```

No conflicts
