### PR TITLE
[17.12] vendor: update archive/tar

### DIFF
--- a/components/engine/vendor.conf
+++ b/components/engine/vendor.conf
@@ -148,7 +148,7 @@ github.com/opencontainers/selinux b29023b86e4a69d1b46b7e7b4e2b6fda03f0b9cd
 # archive/tar
 # mkdir -p ./vendor/archive
 # git clone git://github.com/tonistiigi/go-1.git ./go
-# git --git-dir ./go/.git --work-tree ./go checkout revert-prefix-ignore
+# git --git-dir ./go/.git --work-tree ./go checkout revert-prefix-ignore-1.9
 # cp -a go/src/archive/tar ./vendor/archive/tar
 # rm -rf ./go
 # vndr

--- a/components/engine/vendor/archive/tar/writer.go
+++ b/components/engine/vendor/archive/tar/writer.go
@@ -121,9 +121,15 @@ func (tw *Writer) writeHeader(hdr *Header, allowPax bool) error {
 		needsPaxHeader := paxKeyword != paxNone && len(s) > len(b) || !isASCII(s)
 		if needsPaxHeader {
 			paxHeaders[paxKeyword] = s
-			return
 		}
-		f.formatString(b, s)
+
+		// Write string in a best-effort manner to satisfy readers that expect
+		// the field to be non-empty.
+		s = toASCII(s)
+		if len(s) > len(b) {
+			s = s[:len(b)]
+		}
+		f.formatString(b, s) // Should never error
 	}
 	var formatNumeric = func(b []byte, x int64, paxKeyword string) {
 		// Try octal first.


### PR DESCRIPTION
Backport of https://github.com/moby/moby/pull/35728 (https://github.com/moby/moby/pull/35728/commits/13954b0a6282d919c91626a23967377c19ee7aa2) for 17.12

```
git checkout -b 17.12-backport-vendor-archive upstream/17.12
git cherry-pick -s -S -x -Xsubtree=components/engine 13954b0a6282d919c91626a23967377c19ee7aa2
```

no conflicts