### PR TITLE
[17.12] Pass VERSION to engine static builds

### DIFF
--- a/components/packaging/static/Makefile
+++ b/components/packaging/static/Makefile
@@ -50,10 +50,10 @@ static-cli:
 	$(MAKE) -C $(CLI_DIR) -f docker.Makefile VERSION=$(VERSION) build
 
 static-engine:
-	$(MAKE) -C $(ENGINE_DIR) binary
+	$(MAKE) -C $(ENGINE_DIR) VERSION=$(VERSION) binary
 
 cross-all-cli:
 	$(MAKE) -C $(CLI_DIR) -f docker.Makefile VERSION=$(VERSION) cross
 
 cross-win-engine:
-	$(MAKE) -C $(ENGINE_DIR) DOCKER_CROSSPLATFORMS=windows/amd64 cross
+	$(MAKE) -C $(ENGINE_DIR) VERSION=$(VERSION) DOCKER_CROSSPLATFORMS=windows/amd64 cross


### PR DESCRIPTION
backport:
* https://github.com/docker/docker-ce-packaging/pull/70

VERSION file does not exist anymore for moby/moby so we need to
compensate

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>
(cherry picked from commit c411321b8870101c227b03e64930260984c862fd)
Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>