### PR TITLE
[17.12] Disallow using legacy (V1) registries

### DIFF
--- a/components/cli/contrib/completion/bash/docker
+++ b/components/cli/contrib/completion/bash/docker
@@ -2164,7 +2164,6 @@ _docker_create() {
 _docker_daemon() {
 	local boolean_options="
 		$global_boolean_options
-		--disable-legacy-registry
 		--experimental
 		--help
 		--icc=false

--- a/components/cli/contrib/completion/zsh/_docker
+++ b/components/cli/contrib/completion/zsh/_docker
@@ -2633,7 +2633,6 @@ __docker_subcommand() {
                 "($help)--default-gateway-v6[Container default gateway IPv6 address]:IPv6 address: " \
                 "($help)--default-shm-size=[Default shm size for containers]:size:" \
                 "($help)*--default-ulimit=[Default ulimits for containers]:ulimit: " \
-                "($help)--disable-legacy-registry[Disable contacting legacy registries (default true)]" \
                 "($help)*--dns=[DNS server to use]:DNS: " \
                 "($help)*--dns-opt=[DNS options to use]:DNS option: " \
                 "($help)*--dns-search=[DNS search domains to use]:DNS search: " \

--- a/components/cli/docs/deprecated.md
+++ b/components/cli/docs/deprecated.md
@@ -88,10 +88,10 @@ The daemon is moved to a separate binary (`dockerd`), and should be used instead
 ### Duplicate keys with conflicting values in engine labels
 **Deprecated In Release: [v1.13.0](https://github.com/docker/docker/releases/tag/v1.13.0)**
 
-**Target For Removal In Release: v17.12**
+**Removed In Release: v17.12**
 
-Duplicate keys with conflicting values have been deprecated. A warning is displayed
-in the output, and an error will be returned in the future.
+When setting duplicate keys with conflicting values, an error will be produced, and the daemon
+will fail to start.
 
 ### `MAINTAINER` in Dockerfile
 **Deprecated In Release: [v1.13.0](https://github.com/docker/docker/releases/tag/v1.13.0)**
@@ -110,11 +110,15 @@ future Engine versions. Instead of just requesting, for example, the URL
 ### Backing filesystem without `d_type` support for overlay/overlay2
 **Deprecated In Release: [v1.13.0](https://github.com/docker/docker/releases/tag/v1.13.0)**
 
-**Target For Removal In Release: v17.12**
+**Removed In Release: v17.12**
 
 The overlay and overlay2 storage driver does not work as expected if the backing
 filesystem does not support `d_type`. For example, XFS does not support `d_type`
 if it is formatted with the `ftype=0` option.
+
+Starting with Docker 17.12, new installations will not support running overlay2 on
+a backing filesystem without `d_type` support. For existing installations that upgrade
+to 17.12, a warning will be printed.
 
 Please also refer to [#27358](https://github.com/docker/docker/issues/27358) for
 further information.
@@ -292,7 +296,7 @@ of the `--changes` flag that allows to pass `Dockerfile` commands.
 
 **Disabled By Default In Release: v17.06**
 
-**Target For Removal In Release: v17.12**
+**Removed In Release: v17.12**
 
 Version 1.8.3 added a flag (`--disable-legacy-registry=false`) which prevents the
 docker daemon from `pull`, `push`, and `login` operations against v1
@@ -302,6 +306,21 @@ the v1 protocol.
 Support for the v1 protocol to the public registry was removed in 1.13. Any
 mirror configurations using v1 should be updated to use a
 [v2 registry mirror](https://docs.docker.com/registry/recipes/mirror/).
+
+Starting with Docker 17.12, support for V1 registries has been removed, and the
+`--disable-legacy-registry` flag can no longer be used, and `dockerd` will fail to
+start when set.
+
+### `--disable-legacy-registry` override daemon option
+
+**Disabled In Release: v17.12**
+
+**Target For Removal In Release: v18.03**
+
+The `--disable-legacy-registry` flag was disabled in Docker 17.12 and will print
+an error when used. For this error to be printed, the flag itself is still present,
+but hidden. The flag will be removed in Docker 18.03.
+
 
 ### Docker Content Trust ENV passphrase variables name change
 **Deprecated In Release: [v1.9.0](https://github.com/docker/docker/releases/tag/v1.9.0)**

--- a/components/cli/docs/reference/commandline/dockerd.md
+++ b/components/cli/docs/reference/commandline/dockerd.md
@@ -42,7 +42,6 @@ Options:
       --default-gateway-v6 ip                 Container default gateway IPv6 address
       --default-runtime string                Default OCI runtime for containers (default "runc")
       --default-ulimit ulimit                 Default ulimits for containers (default [])
-      --disable-legacy-registry               Disable contacting legacy registries (default true)
       --dns list                              DNS server to use (default [])
       --dns-opt list                          DNS options to use (default [])
       --dns-search list                       DNS search domains to use (default [])
@@ -1054,18 +1053,14 @@ system's list of trusted CAs instead of enabling `--insecure-registry`.
 
 #### Legacy Registries
 
-Operations against registries supporting only the legacy v1 protocol are
-disabled by default. Specifically, the daemon will not attempt `push`,
-`pull` and `login` to v1 registries. The exception to this is `search`
-which can still be performed on v1 registries.
+Starting with Docker 17.12, operations against registries supporting only the 
+legacy v1 protocol are no longer supported. Specifically, the daemon will not
+attempt `push`, `pull` and `login` to v1 registries. The exception to this is
+`search` which can still be performed on v1 registries.
 
-Add `"disable-legacy-registry":false` to the [daemon configuration
-file](#daemon-configuration-file), or set the
-`--disable-legacy-registry=false` flag, if you need to interact with
-registries that have not yet migrated to the v2 protocol.
+The `disable-legacy-registry` configuration option has been removed and, when
+used, will produce an error on daemon startup.
 
-Interaction v1 registries will no longer be supported in Docker v17.12,
-and the `disable-legacy-registry` configuration option will be removed.
 
 ### Running a Docker daemon behind an HTTPS_PROXY
 
@@ -1339,7 +1334,6 @@ This is a full example of the allowed configuration options on Linux:
 	"registry-mirrors": [],
 	"seccomp-profile": "",
 	"insecure-registries": [],
-	"disable-legacy-registry": false,
 	"no-new-privileges": false,
 	"default-runtime": "runc",
 	"oom-score-adjust": -500,
@@ -1408,8 +1402,7 @@ This is a full example of the allowed configuration options on Windows:
     "raw-logs": false,
     "allow-nondistributable-artifacts": [],
     "registry-mirrors": [],
-    "insecure-registries": [],
-    "disable-legacy-registry": false
+    "insecure-registries": []
 }
 ```
 

--- a/components/cli/man/dockerd.8.md
+++ b/components/cli/man/dockerd.8.md
@@ -26,7 +26,6 @@ dockerd - Enable daemon mode
 [**--default-ipc-mode**=*MODE*]
 [**--default-shm-size**[=*64MiB*]]
 [**--default-ulimit**[=*[]*]]
-[**--disable-legacy-registry**]
 [**--dns**[=*[]*]]
 [**--dns-opt**[=*[]*]]
 [**--dns-search**[=*[]*]]
@@ -196,9 +195,6 @@ $ sudo dockerd --add-runtime runc=runc --add-runtime custom=/usr/local/bin/my-ru
 
 **--default-ulimit**=[]
   Default ulimits for containers.
-
-**--disable-legacy-registry**=*true*|*false*
-  Disable contacting legacy registries. Default is `true`.
 
 **--dns**=""
   Force Docker to use specific DNS servers

--- a/components/engine/cmd/dockerd/config.go
+++ b/components/engine/cmd/dockerd/config.go
@@ -92,6 +92,8 @@ func installRegistryServiceFlags(options *registry.ServiceOptions, flags *pflag.
 	flags.Var(insecureRegistries, "insecure-registry", "Enable insecure registry communication")
 
 	if runtime.GOOS != "windows" {
+		// TODO: Remove this flag after 3 release cycles (18.03)
 		flags.BoolVar(&options.V2Only, "disable-legacy-registry", true, "Disable contacting legacy registries")
+		flags.MarkHidden("disable-legacy-registry")
 	}
 }

--- a/components/engine/cmd/dockerd/daemon.go
+++ b/components/engine/cmd/dockerd/daemon.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -472,8 +473,15 @@ func loadDaemonCliConfig(opts *daemonOptions) (*config.Config, error) {
 		return nil, err
 	}
 
-	if !conf.V2Only {
-		logrus.Warnf(`The "disable-legacy-registry" option is deprecated and wil be removed in Docker v17.12. Interacting with legacy (v1) registries will no longer be supported in Docker v17.12"`)
+	if runtime.GOOS != "windows" {
+		if flags.Changed("disable-legacy-registry") {
+			// TODO: Remove this error after 3 release cycles (18.03)
+			return nil, errors.New("ERROR: The '--disable-legacy-registry' flag has been removed. Interacting with legacy (v1) registries is no longer supported")
+		}
+		if !conf.V2Only {
+			// TODO: Remove this error after 3 release cycles (18.03)
+			return nil, errors.New("ERROR: The 'disable-legacy-registry' configuration option has been removed. Interacting with legacy (v1) registries is no longer supported")
+		}
 	}
 
 	if flags.Changed("graph") {

--- a/components/engine/cmd/dockerd/daemon_unix_test.go
+++ b/components/engine/cmd/dockerd/daemon_unix_test.go
@@ -97,15 +97,3 @@ func TestLoadDaemonConfigWithTrueDefaultValuesLeaveDefaults(t *testing.T) {
 
 	assert.True(t, loadedConfig.EnableUserlandProxy)
 }
-
-func TestLoadDaemonConfigWithLegacyRegistryOptions(t *testing.T) {
-	content := `{"disable-legacy-registry": false}`
-	tempFile := fs.NewFile(t, "config", fs.WithContent(content))
-	defer tempFile.Remove()
-
-	opts := defaultOptions(tempFile.Path())
-	loadedConfig, err := loadDaemonCliConfig(opts)
-	require.NoError(t, err)
-	require.NotNil(t, loadedConfig)
-	assert.False(t, loadedConfig.V2Only)
-}

--- a/components/engine/integration-cli/docker_cli_logout_test.go
+++ b/components/engine/integration-cli/docker_cli_logout_test.go
@@ -13,9 +13,7 @@ import (
 )
 
 func (s *DockerRegistryAuthHtpasswdSuite) TestLogoutWithExternalAuth(c *check.C) {
-
-	// @TODO TestLogoutWithExternalAuth expects docker to fall back to a v1 registry, so has to be updated for v17.12, when v1 registries are no longer supported
-	s.d.StartWithBusybox(c, "--disable-legacy-registry=false")
+	s.d.StartWithBusybox(c)
 
 	osPath := os.Getenv("PATH")
 	defer os.Setenv("PATH", osPath)
@@ -62,7 +60,7 @@ func (s *DockerRegistryAuthHtpasswdSuite) TestLogoutWithExternalAuth(c *check.C)
 	// check I cannot pull anymore
 	out, err := s.d.Cmd("--config", tmp, "pull", repoName)
 	c.Assert(err, check.NotNil, check.Commentf(out))
-	c.Assert(out, checker.Contains, "Error: image dockercli/busybox:authtest not found")
+	c.Assert(out, checker.Contains, "no basic auth credentials")
 }
 
 // #23100

--- a/components/engine/integration-cli/docker_cli_pull_test.go
+++ b/components/engine/integration-cli/docker_cli_pull_test.go
@@ -259,18 +259,6 @@ func (s *DockerHubPullSuite) TestPullClientDisconnect(c *check.C) {
 	c.Assert(err, checker.NotNil, check.Commentf("image was pulled after client disconnected"))
 }
 
-func (s *DockerRegistryAuthHtpasswdSuite) TestPullNoCredentialsNotFound(c *check.C) {
-	// @TODO TestPullNoCredentialsNotFound expects docker to fall back to a v1 registry, so has to be updated for v17.12, when v1 registries are no longer supported
-	s.d.StartWithBusybox(c, "--disable-legacy-registry=false")
-
-	// we don't care about the actual image, we just want to see image not found
-	// because that means v2 call returned 401 and we fell back to v1 which usually
-	// gives a 404 (in this case the test registry doesn't handle v1 at all)
-	out, err := s.d.Cmd("pull", privateRegistryURL+"/busybox")
-	c.Assert(err, check.NotNil, check.Commentf(out))
-	c.Assert(out, checker.Contains, "Error: image busybox:latest not found")
-}
-
 // Regression test for https://github.com/docker/docker/issues/26429
 func (s *DockerSuite) TestPullLinuxImageFailsOnWindows(c *check.C) {
 	testRequires(c, DaemonIsWindows, Network)

--- a/components/engine/integration-cli/docker_cli_v2_only_test.go
+++ b/components/engine/integration-cli/docker_cli_v2_only_test.go
@@ -22,7 +22,7 @@ func makefile(path string, contents string) (string, error) {
 	return f.Name(), nil
 }
 
-// TestV2Only ensures that a daemon by default does not
+// TestV2Only ensures that a daemon does not
 // attempt to contact any v1 registry endpoints.
 func (s *DockerRegistrySuite) TestV2Only(c *check.C) {
 	reg, err := registry.NewMock(c)
@@ -55,66 +55,4 @@ func (s *DockerRegistrySuite) TestV2Only(c *check.C) {
 	s.d.Cmd("tag", "busybox", repoName)
 	s.d.Cmd("push", repoName)
 	s.d.Cmd("pull", repoName)
-}
-
-// TestV1 starts a daemon with legacy registries enabled
-// and ensure v1 endpoints are hit for the following operations:
-// login, push, pull, build & run
-func (s *DockerRegistrySuite) TestV1(c *check.C) {
-	reg, err := registry.NewMock(c)
-	defer reg.Close()
-	c.Assert(err, check.IsNil)
-
-	v2Pings := 0
-	reg.RegisterHandler("/v2/", func(w http.ResponseWriter, r *http.Request) {
-		v2Pings++
-		// V2 ping 404 causes fallback to v1
-		w.WriteHeader(404)
-	})
-
-	v1Pings := 0
-	reg.RegisterHandler("/v1/_ping", func(w http.ResponseWriter, r *http.Request) {
-		v1Pings++
-	})
-
-	v1Logins := 0
-	reg.RegisterHandler("/v1/users/", func(w http.ResponseWriter, r *http.Request) {
-		v1Logins++
-	})
-
-	v1Repo := 0
-	reg.RegisterHandler("/v1/repositories/busybox/", func(w http.ResponseWriter, r *http.Request) {
-		v1Repo++
-	})
-
-	reg.RegisterHandler("/v1/repositories/busybox/images", func(w http.ResponseWriter, r *http.Request) {
-		v1Repo++
-	})
-
-	s.d.Start(c, "--insecure-registry", reg.URL(), "--disable-legacy-registry=false")
-
-	tmp, err := ioutil.TempDir("", "integration-cli-")
-	c.Assert(err, check.IsNil)
-	defer os.RemoveAll(tmp)
-
-	dockerfileName, err := makefile(tmp, fmt.Sprintf("FROM %s/busybox", reg.URL()))
-	c.Assert(err, check.IsNil, check.Commentf("Unable to create test dockerfile"))
-
-	s.d.Cmd("build", "--file", dockerfileName, tmp)
-	c.Assert(v1Repo, check.Equals, 1, check.Commentf("Expected v1 repository access after build"))
-
-	repoName := fmt.Sprintf("%s/busybox", reg.URL())
-	s.d.Cmd("run", repoName)
-	c.Assert(v1Repo, check.Equals, 2, check.Commentf("Expected v1 repository access after run"))
-
-	s.d.Cmd("login", "-u", "richard", "-p", "testtest", reg.URL())
-	c.Assert(v1Logins, check.Equals, 1, check.Commentf("Expected v1 login attempt"))
-
-	s.d.Cmd("tag", "busybox", repoName)
-	s.d.Cmd("push", repoName)
-
-	c.Assert(v1Repo, check.Equals, 2)
-
-	s.d.Cmd("pull", repoName)
-	c.Assert(v1Repo, check.Equals, 3, check.Commentf("Expected v1 repository access after pull"))
 }


### PR DESCRIPTION
Backport of https://github.com/moby/moby/pull/35751 and https://github.com/docker/cli/pull/747 for 17.12

No conflicts



Interacting with v1 registries was deprecated in Docker 1.8.3, disabled by default
in Docker 17.06, and scheduled for removal in Docker 17.12.

This patch disallows enabling V1 registry through the `--disable-legacy-registry`
option, and the `"disable-legacy-registry": false` option in the daemon configuration
file. The actual V1 registry code is still in place, and will be removed separately.

With this patch applied:

    $ dockerd --disable-legacy-registry=false
    ERROR: The '--disable-legacy-registry' flag has been removed. Interacting with legacy (v1) registries is no longer supported

Or, when setting through the `daemon.json` configuration file

    $ mkdir -p /etc/docker/
    $ echo '{"disable-legacy-registry":false}' > /etc/docker/daemon.json
    $ dockerd
    ERROR: The 'disable-legacy-registry' configuration option has been removed. Interacting with legacy (v1) registries is no longer supported

(cherry picked from commit 8d6df8a0addc9a37b48c5a1827dd3f65f2ed57cf)
