### PR TITLE
[17.12] backport 35613 update go gelf v2 for bugfix

### DIFF
--- a/components/engine/vendor.conf
+++ b/components/engine/vendor.conf
@@ -77,7 +77,7 @@ github.com/syndtr/gocapability 2c00daeb6c3b45114c80ac44119e7b8801fdd852
 github.com/golang/protobuf 7a211bcf3bce0e3f1d74f9894916e6f116ae83b4
 
 # gelf logging driver deps
-github.com/Graylog2/go-gelf v2
+github.com/Graylog2/go-gelf ba920adcee0319adcc15f52851f1458f56547975
 
 github.com/fluent/fluent-logger-golang v1.3.0
 # fluent-logger-golang deps

--- a/components/engine/vendor.conf
+++ b/components/engine/vendor.conf
@@ -77,7 +77,7 @@ github.com/syndtr/gocapability 2c00daeb6c3b45114c80ac44119e7b8801fdd852
 github.com/golang/protobuf 7a211bcf3bce0e3f1d74f9894916e6f116ae83b4
 
 # gelf logging driver deps
-github.com/Graylog2/go-gelf ba920adcee0319adcc15f52851f1458f56547975
+github.com/Graylog2/go-gelf 4143646226541087117ff2f83334ea48b3201841
 
 github.com/fluent/fluent-logger-golang v1.3.0
 # fluent-logger-golang deps

--- a/components/engine/vendor/github.com/Graylog2/go-gelf/gelf/writer.go
+++ b/components/engine/vendor/github.com/Graylog2/go-gelf/gelf/writer.go
@@ -27,5 +27,8 @@ type GelfWriter struct {
 
 // Close connection and interrupt blocked Read or Write operations
 func (w *GelfWriter) Close() error {
+	if w.conn == nil {
+		return nil
+	}
 	return w.conn.Close()
 }


### PR DESCRIPTION
Backport of https://github.com/moby/moby/pull/35765 for 17.12

```
git checkout -b 17.12-backport-35613-update-go-gelf-v2-for-bugfix upstream/17.12
git cherry-pick -s -S -x -Xsubtree=components/engine 5bc11021250e39e71ca9edf62ce5c33f15c3756f
git cherry-pick -s -S -x -Xsubtree=components/engine f9f3c49302fc80e586e3cb10af43114929556b47
```

No conflicts

ping @anusha-ragunathan @andrewhsu @cpuguy83 PTAL