### PR TITLE
[17.12] backport docs and completion

### DIFF
--- a/components/cli/contrib/completion/bash/docker
+++ b/components/cli/contrib/completion/bash/docker
@@ -2220,6 +2220,7 @@ _docker_daemon() {
 		--metrics-addr
 		--mtu
 		--network-control-plane-mtu
+		--node-generic-resource
 		--oom-score-adjust
 		--pidfile -p
 		--registry-mirror
@@ -3395,6 +3396,7 @@ _docker_service_update_and_create() {
 			--dns-option
 			--dns-search
 			--env-file
+			--generic-resource
 			--group
 			--host
 			--mode
@@ -3456,6 +3458,8 @@ _docker_service_update_and_create() {
 			--dns-rm
 			--dns-search-add
 			--dns-search-rm
+			--generic-resource-add
+			--generic-resource-rm
 			--group-add
 			--group-rm
 			--host-add

--- a/components/cli/contrib/completion/bash/docker
+++ b/components/cli/contrib/completion/bash/docker
@@ -2866,6 +2866,7 @@ _docker_inspect() {
 						$(__docker_services)
 						$(__docker_volumes)
 					" -- "$cur" ) )
+					__ltrim_colon_completions "$cur"
 					;;
 				container)
 					__docker_complete_containers_all

--- a/components/cli/contrib/completion/zsh/_docker
+++ b/components/cli/contrib/completion/zsh/_docker
@@ -745,7 +745,7 @@ __docker_container_subcommand() {
                 "($help)--privileged[Give extended Linux capabilities to the command]" \
                 "($help -t --tty)"{-t,--tty}"[Allocate a pseudo-tty]" \
                 "($help -u --user)"{-u=,--user=}"[Username or UID]:user:_users" \
-                "($help -w --workdir)"{-w=,--workdir=}"[Working directory inside the container]:directory:_directories"
+                "($help -w --workdir)"{-w=,--workdir=}"[Working directory inside the container]:directory:_directories" \
                 "($help -):containers:__docker_complete_running_containers" \
                 "($help -)*::command:->anycommand" && ret=0
             case $state in

--- a/components/cli/docs/reference/commandline/run.md
+++ b/components/cli/docs/reference/commandline/run.md
@@ -588,11 +588,11 @@ Use Docker's `--restart` to specify a container's *restart policy*. A restart
 policy controls whether the Docker daemon restarts a container after exit.
 Docker supports the following restart policies:
 
-| Policy    | Result                                                                                                                                                                                                                                                           |
-|:----------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `no`      | Do not automatically restart the container when it exits. This is the default.                                                                                                                                                                                   |
-| `failure` | Restart only if the container exits with a non-zero exit status. Optionally, limit the number of restart retries the Docker daemon attempts.                                                                                                                     |
-| `always`  | Always restart the container regardless of the exit status. When you specify always, the Docker daemon will try to restart the container indefinitely. The container will also always start on daemon startup, regardless of the current state of the container. |
+| Policy                     | Result                                                                                                                                                                                                                                                           |
+|:---------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `no`                       | Do not automatically restart the container when it exits. This is the default.                                                                                                                                                                                   |
+| `on-failure[:max-retries]` | Restart only if the container exits with a non-zero exit status. Optionally, limit the number of restart retries the Docker daemon attempts.                                                                                                                     |
+| `always`                   | Always restart the container regardless of the exit status. When you specify always, the Docker daemon will try to restart the container indefinitely. The container will also always start on daemon startup, regardless of the current state of the container. |
 
 ```bash
 $ docker run --restart=always redis


### PR DESCRIPTION
Cherry-picks for 17.12 of:

- https://github.com/docker/cli/pull/751/commits/db05d8ad79e34e8096f31585fe9ffe0ce18f98d8 (https://github.com/docker/cli/pull/751) ("Fix error in zsh completion script for docker exec")
- https://github.com/docker/cli/pull/754/commits/43217d733205b0694f791e7326bfed6d13b645f0 (https://github.com/docker/cli/pull/754) (Fix "on-failure" restart policy being documented as "failure")
- https://github.com/docker/cli/pull/749/commits/8ec80eec672b93be03843412f195fae477e81c4a (https://github.com/docker/cli/pull/749) (Add support for generic resources to bash completion)
- https://github.com/docker/cli/pull/713/commits/a2d0b6e122021cfac87a99a46d3d02339552d281 (https://github.com/docker/cli/pull/713) (Fix Bash autocompletion works incorrect with inspect)

```
git checkout -b 17.12-backport-docs-and-completion upstream/17.12  
git cherry-pick -s -S -x -Xsubtree=components/cli 43217d733205b0694f791e7326bfed6d13b645f0
git cherry-pick -s -S -x -Xsubtree=components/cli db05d8ad79e34e8096f31585fe9ffe0ce18f98d8
git cherry-pick -s -S -x -Xsubtree=components/cli 8ec80eec672b93be03843412f195fae477e81c4a
git cherry-pick -s -S -x -Xsubtree=components/cli a2d0b6e122021cfac87a99a46d3d02339552d281
```

no conflicts

ping @mistyhacks @andrewhsu PTAL