### PR TITLE
[17.12] Windows: Case-insensitive filename matching against builder cache

### DIFF
--- a/components/engine/pkg/tarsum/fileinfosums.go
+++ b/components/engine/pkg/tarsum/fileinfosums.go
@@ -1,6 +1,10 @@
 package tarsum
 
-import "sort"
+import (
+	"runtime"
+	"sort"
+	"strings"
+)
 
 // FileInfoSumInterface provides an interface for accessing file checksum
 // information within a tar file. This info is accessed through interface
@@ -35,8 +39,11 @@ type FileInfoSums []FileInfoSumInterface
 
 // GetFile returns the first FileInfoSumInterface with a matching name.
 func (fis FileInfoSums) GetFile(name string) FileInfoSumInterface {
+	// We do case insensitive matching on Windows as c:\APP and c:\app are
+	// the same. See issue #33107.
 	for i := range fis {
-		if fis[i].Name() == name {
+		if (runtime.GOOS == "windows" && strings.EqualFold(fis[i].Name(), name)) ||
+			(runtime.GOOS != "windows" && fis[i].Name() == name) {
 			return fis[i]
 		}
 	}


### PR DESCRIPTION
Backport of https://github.com/moby/moby/pull/35793 for 17.12

```
git checkout -b 17.12-backport-33107 upstream/17.12  
git cherry-pick -s -S -x -Xsubtree=components/engine 7caa30e8937b65ad9fd61a8b811bba470d22809f
```

no conflicts

(cherry picked from commit 7caa30e8937b65ad9fd61a8b811bba470d22809f)
