### PR TITLE
[17.12]  bump vndr of swarmkit to 2e6f892

### DIFF
--- a/components/engine/vendor.conf
+++ b/components/engine/vendor.conf
@@ -114,7 +114,7 @@ github.com/dmcgowan/go-tar go1.10
 github.com/stevvooe/ttrpc 76e68349ad9ab4d03d764c713826d31216715e4f
 
 # cluster
-github.com/docker/swarmkit 4429c763170d9ca96929249353c3270c19e7d39e
+github.com/docker/swarmkit 2e6f892e2def5835420c043420f7294dd28012a6
 github.com/gogo/protobuf v0.4
 github.com/cloudflare/cfssl 7fb22c8cba7ecaf98e4082d22d65800cf45e042a
 github.com/google/certificate-transparency d90e65c3a07988180c5b1ece71791c0b6506826e

--- a/components/engine/vendor/github.com/docker/swarmkit/manager/allocator/cnmallocator/networkallocator.go
+++ b/components/engine/vendor/github.com/docker/swarmkit/manager/allocator/cnmallocator/networkallocator.go
@@ -404,6 +404,11 @@ func (na *cnmNetworkAllocator) IsServiceAllocated(s *api.Service, flags ...func(
 	vipLoop:
 		for _, vip := range s.Endpoint.VirtualIPs {
 			if na.IsVIPOnIngressNetwork(vip) && networkallocator.IsIngressNetworkNeeded(s) {
+				// This checks the condition when ingress network is needed
+				// but allocation has not been done.
+				if _, ok := na.services[s.ID]; !ok {
+					return false
+				}
 				continue vipLoop
 			}
 			for _, net := range specNetworks {


### PR DESCRIPTION
Fixes: 
* https://github.com/docker/libnetwork/issues/1790#issuecomment-308222053

Comparison of upstream changes: https://github.com/docker/swarmkit/compare/4429c763170d9ca96929249353c3270c19e7d39e...2e6f892e2def5835420c043420f7294dd28012a6


Brings in these changes:
* https://github.com/docker/swarmkit/pull/2474 [17.12] Added required call to allocate VIPs when endpoints are restored 


Signed-off-by: jose-bigio <jose.bigio@docker.com>