### PR TITLE
[17.12] Fix VFS vs quota regression

### DIFF
--- a/components/engine/daemon/graphdriver/quota/projectquota.go
+++ b/components/engine/daemon/graphdriver/quota/projectquota.go
@@ -350,11 +350,17 @@ func makeBackingFsDev(home string) (string, error) {
 	backingFsBlockDev := path.Join(home, "backingFsBlockDev")
 	// Re-create just in case someone copied the home directory over to a new device
 	unix.Unlink(backingFsBlockDev)
-	if err := unix.Mknod(backingFsBlockDev, unix.S_IFBLK|0600, int(stat.Dev)); err != nil {
+	err := unix.Mknod(backingFsBlockDev, unix.S_IFBLK|0600, int(stat.Dev))
+	switch err {
+	case nil:
+		return backingFsBlockDev, nil
+
+	case unix.ENOSYS:
+		return "", ErrQuotaNotSupported
+
+	default:
 		return "", fmt.Errorf("Failed to mknod %s: %v", backingFsBlockDev, err)
 	}
-
-	return backingFsBlockDev, nil
 }
 
 func hasQuotaSupport(backingFsBlockDev string) (bool, error) {

--- a/components/engine/daemon/graphdriver/vfs/driver.go
+++ b/components/engine/daemon/graphdriver/vfs/driver.go
@@ -35,9 +35,7 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 		return nil, err
 	}
 
-	if err := setupDriverQuota(d); err != nil {
-		return nil, err
-	}
+	setupDriverQuota(d)
 
 	return graphdriver.NewNaiveDiffDriver(d, uidMaps, gidMaps), nil
 }

--- a/components/engine/daemon/graphdriver/vfs/quota_linux.go
+++ b/components/engine/daemon/graphdriver/vfs/quota_linux.go
@@ -2,20 +2,21 @@
 
 package vfs
 
-import "github.com/docker/docker/daemon/graphdriver/quota"
+import (
+	"github.com/docker/docker/daemon/graphdriver/quota"
+	"github.com/sirupsen/logrus"
+)
 
 type driverQuota struct {
 	quotaCtl *quota.Control
 }
 
-func setupDriverQuota(driver *Driver) error {
+func setupDriverQuota(driver *Driver) {
 	if quotaCtl, err := quota.NewControl(driver.home); err == nil {
 		driver.quotaCtl = quotaCtl
 	} else if err != quota.ErrQuotaNotSupported {
-		return err
+		logrus.Warnf("Unable to setup quota: %v\n", err)
 	}
-
-	return nil
 }
 
 func (d *Driver) setupQuota(dir string, size uint64) error {


### PR DESCRIPTION
back port of https://github.com/moby/moby/pull/35827 for 17.12.x

```
git checkout -b backport-vfs-quota upstream/17.12
git cherry-pick -s -S -x -Xsubtree=components/engine 2dd39b7841bdb9968884bbedc5db97ff77d4fe3e
git cherry-pick -s -S -x -Xsubtree=components/engine 1e8a087850aa9f96c5000a3ad90757d2e9c0499f
```

No conclicts


ping @kolyshkin @cpuguy83 