### PR TITLE
[17.12] Return errors from client in stack deploy configs

### DIFF
--- a/components/cli/cli/command/stack/deploy_composefile.go
+++ b/components/cli/cli/command/stack/deploy_composefile.go
@@ -248,13 +248,13 @@ func createConfigs(
 		case err == nil:
 			// config already exists, then we update that
 			if err := client.ConfigUpdate(ctx, config.ID, config.Meta.Version, configSpec); err != nil {
-				errors.Wrapf(err, "failed to update config %s", configSpec.Name)
+				return errors.Wrapf(err, "failed to update config %s", configSpec.Name)
 			}
 		case apiclient.IsErrNotFound(err):
 			// config does not exist, then we create a new one.
 			fmt.Fprintf(dockerCli.Out(), "Creating config %s\n", configSpec.Name)
 			if _, err := client.ConfigCreate(ctx, configSpec); err != nil {
-				errors.Wrapf(err, "failed to create config %s", configSpec.Name)
+				return errors.Wrapf(err, "failed to create config %s", configSpec.Name)
 			}
 		default:
 			return err


### PR DESCRIPTION
Cherry-pick of https://github.com/docker/cli/pull/757 for 17.12.x

```
git checkout -b backport-fix-missing-errors upstream/17.12
git cherry-pick -s -S -x -Xsubtree=components/cli a30dd1b6f35541a1ae32df67e7bdd38d0535aab9
```

(no conflicts)

ping @dnephin @vdemeester 