### PR TITLE
[17.12] Fix event filter filtering on "or"

### DIFF
--- a/components/engine/libcontainerd/client_daemon.go
+++ b/components/engine/libcontainerd/client_daemon.go
@@ -715,8 +715,9 @@ func (c *client) processEventStream(ctx context.Context) {
 
 	eventStream, err = c.remote.EventService().Subscribe(ctx, &eventsapi.SubscribeRequest{
 		Filters: []string{
-			"namespace==" + c.namespace,
-			"topic~=/tasks/",
+			// Filter on both namespace *and* topic. To create an "and" filter,
+			// this must be a single, comma-separated string
+			"namespace==" + c.namespace + ",topic~=|^/tasks/|",
 		},
 	}, grpc.FailFast(false))
 	if err != nil {


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/35896 for 17.12.x

```
git checkout -b 17.12-backport-fix-namespace-filtering upstream/17.12
git cherry-pick -s -S -x -Xsubtree=components/engine 295bb09184fe473933498bb0efb59b8acb124f55
```

No conflicts


The event filter used two separate filter-conditions for "namespace" and "topic". As a result, both events matching "topic" and events matching "namespace" were subscribed to, causing events to be handled both by the "plugin" client, and "container" client.

This patch rewrites the filter to match only if both namespace and topic match.

Thanks to Stephen Day for providing the correct filter :)

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
(cherry picked from commit 295bb09184fe473933498bb0efb59b8acb124f55)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>


@crosbymichael @stevvooe PTAL