### PR TITLE
[17.09] backport checkpoint dir fix

### DIFF
--- a/components/engine/daemon/checkpoint.go
+++ b/components/engine/daemon/checkpoint.go
@@ -21,7 +21,7 @@ func getCheckpointDir(checkDir, checkpointID string, ctrName string, ctrID strin
 	var checkpointDir string
 	var err2 error
 	if checkDir != "" {
-		checkpointDir = filepath.Join(checkDir, ctrID, "checkpoints")
+		checkpointDir = checkDir
 	} else {
 		checkpointDir = ctrCheckpointDir
 	}


### PR DESCRIPTION
Cherry-pick for 17.09.1 of:

- https://github.com/moby/moby/pull/35694 Don't append the container id to custom directory checkpoints.

<pre>git checkout -b 17.09-backport-checkpoint-dir-fix upstream/17.09
git cherry-pick -s -S -x -Xsubtree=components/engine e51aec992624fec305176866f3937e0a120cecb8</pre>
