### PR TITLE
[18.01] Revert "Bump API version to 1.36"

### DIFF
--- a/components/engine/api/common.go
+++ b/components/engine/api/common.go
@@ -3,7 +3,7 @@ package api
 // Common constants for daemon and client.
 const (
 	// DefaultVersion of Current REST API
-	DefaultVersion string = "1.36"
+	DefaultVersion string = "1.35"
 
 	// NoBaseImageSpecifier is the symbol used by the FROM
 	// command to specify that no base image is to be used.

--- a/components/engine/api/swagger.yaml
+++ b/components/engine/api/swagger.yaml
@@ -19,10 +19,10 @@ produces:
 consumes:
   - "application/json"
   - "text/plain"
-basePath: "/v1.36"
+basePath: "/v1.35"
 info:
   title: "Docker Engine API"
-  version: "1.36"
+  version: "1.35"
   x-logo:
     url: "https://docs.docker.com/images/logo-docker-main.png"
   description: |
@@ -49,8 +49,8 @@ info:
     the URL is not supported by the daemon, a HTTP `400 Bad Request` error message
     is returned.
 
-    If you omit the version-prefix, the current version of the API (v1.36) is used.
-    For example, calling `/info` is the same as calling `/v1.36/info`. Using the
+    If you omit the version-prefix, the current version of the API (v1.35) is used.
+    For example, calling `/info` is the same as calling `/v1.35/info`. Using the
     API without a version-prefix is deprecated and will be removed in a future release.
 
     Engine releases in the near future should support this version of the API,

--- a/components/engine/docs/api/version-history.md
+++ b/components/engine/docs/api/version-history.md
@@ -13,11 +13,6 @@ keywords: "API, Docker, rcli, REST, documentation"
      will be rejected.
 -->
 
-## v1.36 API changes
-
-[Docker Engine API v1.36](https://docs.docker.com/engine/api/v1.36/) documentation
-
-
 ## v1.35 API changes
 
 [Docker Engine API v1.35](https://docs.docker.com/engine/api/v1.35/) documentation


### PR DESCRIPTION
There were no changes made yet to the API, so no need to bump the API version for this release

This reverts commit c1e982f2ee85580687e2d355af3ca444ada14d01 (https://github.com/moby/moby/pull/35738)

```
git checkout -b 18.01-revert-api-bump upstream/18.01
git revert -s -S -Xsubtree=components/engine c1e982f2ee85580687e2d355af3ca444ada14d01
```

