### PR TITLE
[18.01] Download support of images with multi-arch manifest

### DIFF
--- a/components/engine/hack/make/.detect-daemon-osarch
+++ b/components/engine/hack/make/.detect-daemon-osarch
@@ -64,7 +64,9 @@ case "$PACKAGE_ARCH" in
 		;;
 	*)
 		DOCKERFILE="Dockerfile.$PACKAGE_ARCH"
-		TEST_IMAGE_NAMESPACE="$PACKAGE_ARCH"
+		if [ "$PACKAGE_ARCH" != "aarch64" ]; then
+			TEST_IMAGE_NAMESPACE="$PACKAGE_ARCH"
+		fi
 		;;
 esac
 export DOCKERFILE TEST_IMAGE_NAMESPACE


### PR DESCRIPTION
building aarch64 static binaries with docker-ce 18.01 code is failing with error:
```
00:09:54 error: unknown manifest mediaType (library/buildpack-deps:jessie@sha256:dd86dced7c9cd2a724e779730f0a53f93b7ef42228d4344b25ce9a42a1486251): 'application/vnd.docker.distribution.manifest.list.v2+json'
00:09:56 The command '/bin/sh -c ./contrib/download-frozen-image-v2.sh /docker-frozen-images 	buildpack-deps:jessie@sha256:dd86dced7c9cd2a724e779730f0a53f93b7ef42228d4344b25ce9a42a1486251 	busybox:latest@sha256:bbc3a03235220b170ba48a157dd097dd1379299370e1ed99ce976df0355d24f0 	debian:jessie@sha256:287a20c5f73087ab406e6b364833e3fb7b3ae63ca0eb3486555dc27ed32c6e60 	hello-world:latest@sha256:be0cd392e45be79ffeffa6b05338b98ebb16c87b255f48e297ec7f98e123905c' returned a non-zero code: 1
00:09:56 Makefile:124: recipe for target 'build' failed
00:09:56 make[1]: *** [build] Error 1
```

this pr will backport what looks like the fix:
* https://github.com/moby/moby/pull/35772  Download support of images with multi-arch manifest

with cherry-pick of moby/moby@0af5db5:
```
$ git cherry-pick -s -x -Xsubtree=components/engine 0af5db5
```

no conflicts.