### PR TITLE
[18.01] Vendor Microsoft/hcsshim @ v0.6.8

### DIFF
--- a/components/engine/vendor.conf
+++ b/components/engine/vendor.conf
@@ -1,6 +1,6 @@
 # the following lines are in sorted order, FYI
 github.com/Azure/go-ansiterm d6e3b3328b783f23731bc4d058875b0371ff8109
-github.com/Microsoft/hcsshim v0.6.7
+github.com/Microsoft/hcsshim v0.6.8
 github.com/Microsoft/go-winio v0.4.5
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
 github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/35924 for 18.01

```
git checkout -b 18.01-backport-32838-partial-fix upstream/18.01
git cherry-pick -s -S -x -Xsubtree=components/engine 172a442c27ed35778662980809824fdf15a722a6
```

no conflicts