### PR TITLE
[18.01] Fix docs YAML generation setting "kubernetes" for "swarm"

### DIFF
--- a/components/cli/docs/yaml/yaml.go
+++ b/components/cli/docs/yaml/yaml.go
@@ -123,7 +123,7 @@ func GenYamlCustom(cmd *cobra.Command, w io.Writer) error {
 			cliDoc.Kubernetes = true
 		}
 		if _, ok := curr.Annotations["swarm"]; ok && !cliDoc.Swarm {
-			cliDoc.Kubernetes = true
+			cliDoc.Swarm = true
 		}
 	}
 
@@ -208,7 +208,7 @@ func genFlagResult(flags *pflag.FlagSet) []cmdOption {
 			opt.Kubernetes = true
 		}
 		if _, ok := flag.Annotations["swarm"]; ok {
-			opt.Kubernetes = true
+			opt.Swarm = true
 		}
 
 		result = append(result, opt)


### PR DESCRIPTION
backport fix:
* https://github.com/docker/cli/pull/802 Fix docs YAML generation setting "kubernetes" for "swarm"

with cherry-pick of git commit https://github.com/docker/cli/pull/802/commits/6be06a3:
```
$ git cherry-pick -s -x -Xsubtree=components/cli 6be06a3
```

no conflicts.