### PR TITLE
[17.12] Fixing ingress network when upgrading from 17.09 to 17.12.

### DIFF
--- a/components/engine/daemon/cluster/executor/container/executor.go
+++ b/components/engine/daemon/cluster/executor/container/executor.go
@@ -146,6 +146,11 @@ func (e *executor) Configure(ctx context.Context, node *api.Node) error {
 		attachments[na.Network.ID] = na.Addresses[0]
 	}
 
+	if (ingressNA == nil) && (node.Attachment != nil) {
+		ingressNA = node.Attachment
+		attachments[ingressNA.Network.ID] = ingressNA.Addresses[0]
+	}
+
 	if ingressNA == nil {
 		e.backend.ReleaseIngress()
 		return e.backend.GetAttachmentStore().ResetAttachments(attachments)


### PR DESCRIPTION
Backport of https://github.com/moby/moby/pull/36003 for 17.12 (fixes https://github.com/moby/moby/issues/35941)

```
git checkout -b 17.12-backport-upgrade_fix upstream/17.12
git cherry-pick -s -S -x -Xsubtree=components/engine 2d7a50e5855ad0571e76d29cd1ab9f8f3a48433b
git push --set-upstream origin 17.12-backport-upgrade_fix
```
(cherry picked from commit 2d7a50e5855ad0571e76d29cd1ab9f8f3a48433b)

no conflicts
