### PR TITLE
[17.12] Re-validate Mounts on container start

### DIFF
--- a/components/engine/volume/lcow_parser.go
+++ b/components/engine/volume/lcow_parser.go
@@ -22,7 +22,7 @@ type lcowParser struct {
 	windowsParser
 }
 
-func (p *lcowParser) validateMountConfig(mnt *mount.Mount) error {
+func (p *lcowParser) ValidateMountConfig(mnt *mount.Mount) error {
 	return p.validateMountConfigReg(mnt, rxLCOWDestination, lcowSpecificValidators)
 }
 

--- a/components/engine/volume/linux_parser.go
+++ b/components/engine/volume/linux_parser.go
@@ -40,7 +40,7 @@ func linuxValidateAbsolute(p string) error {
 	}
 	return fmt.Errorf("invalid mount path: '%s' mount path must be absolute", p)
 }
-func (p *linuxParser) validateMountConfig(mnt *mount.Mount) error {
+func (p *linuxParser) ValidateMountConfig(mnt *mount.Mount) error {
 	// there was something looking like a bug in existing codebase:
 	// - validateMountConfig on linux was called with options skipping bind source existence when calling ParseMountRaw
 	// - but not when calling ParseMountSpec directly... nor when the unit test called it directly

--- a/components/engine/volume/parser.go
+++ b/components/engine/volume/parser.go
@@ -26,8 +26,7 @@ type Parser interface {
 	IsBackwardCompatible(m *MountPoint) bool
 	HasResource(m *MountPoint, absPath string) bool
 	ValidateTmpfsMountDestination(dest string) error
-
-	validateMountConfig(mt *mount.Mount) error
+	ValidateMountConfig(mt *mount.Mount) error
 }
 
 // NewParser creates a parser for a given container OS, depending on the current host OS (linux on a windows host will resolve to an lcowParser)

--- a/components/engine/volume/validate_test.go
+++ b/components/engine/volume/validate_test.go
@@ -31,13 +31,9 @@ func TestValidateMount(t *testing.T) {
 
 		{mount.Mount{Type: mount.TypeBind, Source: testDir, Target: testDestinationPath}, nil},
 		{mount.Mount{Type: "invalid", Target: testDestinationPath}, errors.New("mount type unknown")},
+		{mount.Mount{Type: mount.TypeBind, Source: testSourcePath, Target: testDestinationPath}, errBindNotExist},
 	}
-	if runtime.GOOS == "windows" {
-		cases = append(cases, struct {
-			input    mount.Mount
-			expected error
-		}{mount.Mount{Type: mount.TypeBind, Source: testSourcePath, Target: testDestinationPath}, errBindNotExist}) // bind source existance is not checked on linux
-	}
+
 	lcowCases := []struct {
 		input    mount.Mount
 		expected error
@@ -54,7 +50,7 @@ func TestValidateMount(t *testing.T) {
 	}
 	parser := NewParser(runtime.GOOS)
 	for i, x := range cases {
-		err := parser.validateMountConfig(&x.input)
+		err := parser.ValidateMountConfig(&x.input)
 		if err == nil && x.expected == nil {
 			continue
 		}
@@ -65,7 +61,7 @@ func TestValidateMount(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		parser = &lcowParser{}
 		for i, x := range lcowCases {
-			err := parser.validateMountConfig(&x.input)
+			err := parser.ValidateMountConfig(&x.input)
 			if err == nil && x.expected == nil {
 				continue
 			}

--- a/components/engine/volume/windows_parser.go
+++ b/components/engine/volume/windows_parser.go
@@ -189,7 +189,7 @@ func (p *windowsParser) ValidateVolumeName(name string) error {
 	}
 	return nil
 }
-func (p *windowsParser) validateMountConfig(mnt *mount.Mount) error {
+func (p *windowsParser) ValidateMountConfig(mnt *mount.Mount) error {
 	return p.validateMountConfigReg(mnt, rxDestination, windowsSpecificValidators)
 }
 


### PR DESCRIPTION
back port of https://github.com/moby/moby/pull/35833 for 17.12

```
git checkout -b 17.12-backport-fix-mount-creation-on-start upstream/17.12
git cherry-pick -s -S -x -Xsubtree=components/engine 7cb96ba308dc53824d2203fd343a4a297d17976e
```

no conflicts

Validation of Mounts was only performed on container _creation_, not on
container _start_. As a result, if the host-path no longer existed
when the container was started, a directory was created in the given
location.

This is the wrong behavior, because when using the `Mounts` API, host paths
should never be created, and an error should be produced instead.

This patch adds a validation step on container start, and produces an
error if the host path is not found.