### PR TITLE
[17.12] Honor DOCKER_RAMDISK with containerd 1.0

### DIFF
--- a/components/engine/libcontainerd/client_daemon.go
+++ b/components/engine/libcontainerd/client_daemon.go
@@ -262,8 +262,9 @@ func (c *client) Start(ctx context.Context, id, checkpointDir string, withStdin 
 		func(_ context.Context, _ *containerd.Client, info *containerd.TaskInfo) error {
 			info.Checkpoint = cp
 			info.Options = &runctypes.CreateOptions{
-				IoUid: uint32(uid),
-				IoGid: uint32(gid),
+				IoUid:       uint32(uid),
+				IoGid:       uint32(gid),
+				NoPivotRoot: os.Getenv("DOCKER_RAMDISK") != "",
 			}
 			return nil
 		})


### PR DESCRIPTION
back port of https://github.com/moby/moby/pull/35957 for 17.12

```
git checkout -b 17.12-backport-ramdisk upstream/17.12
git cherry-pick -s -S -x -Xsubtree=components/engine 54051e9e64185e442e034c7e49a5707459a9eed2
```

no conflicts