### PR TITLE
[17.12] bump libnetwork to 0ef1f8c94fa85acacf88b9be75ae07de91d0b2a5

### DIFF
--- a/components/engine/vendor.conf
+++ b/components/engine/vendor.conf
@@ -30,7 +30,7 @@ github.com/moby/buildkit aaff9d591ef128560018433fe61beb802e149de8
 github.com/tonistiigi/fsutil dea3a0da73aee887fc02142d995be764106ac5e2
 
 #get libnetwork packages
-github.com/docker/libnetwork 7dd202d11b2078c063fefc614c9fb9e4615da0e1
+github.com/docker/libnetwork cb462375d91926adfce98bd8a1f47a325ed6f8f2
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/components/engine/vendor.conf
+++ b/components/engine/vendor.conf
@@ -30,7 +30,7 @@ github.com/moby/buildkit aaff9d591ef128560018433fe61beb802e149de8
 github.com/tonistiigi/fsutil dea3a0da73aee887fc02142d995be764106ac5e2
 
 #get libnetwork packages
-github.com/docker/libnetwork cb462375d91926adfce98bd8a1f47a325ed6f8f2
+github.com/docker/libnetwork 0ef1f8c94fa85acacf88b9be75ae07de91d0b2a5
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/components/engine/vendor/github.com/docker/libnetwork/osl/namespace_linux.go
+++ b/components/engine/vendor/github.com/docker/libnetwork/osl/namespace_linux.go
@@ -220,9 +220,11 @@ func NewSandbox(key string, osCreate, isRestore bool) (Sandbox, error) {
 	if err != nil {
 		logrus.Warnf("Failed to set the timeout on the sandbox netlink handle sockets: %v", err)
 	}
-
+	// In live-restore mode, IPV6 entries are getting cleaned up due to below code
+	// We should retain IPV6 configrations in live-restore mode when Docker Daemon
+	// comes back. It should work as it is on other cases
 	// As starting point, disable IPv6 on all interfaces
-	if !n.isDefault {
+	if !isRestore && !n.isDefault {
 		err = setIPv6(n.path, "all", false)
 		if err != nil {
 			logrus.Warnf("Failed to disable IPv6 on all interfaces on network namespace %q: %v", n.path, err)


### PR DESCRIPTION
Brings in a cherry pick of https://github.com/docker/libnetwork/commit/76bfcb0eb14686d3c25683df22e14bc1d3b093ef

In sandbox creation we disable IPV6 config. But this causes problem in live-restore case
where all IPV6 configs are wiped out on running container. Hence extra check has been added
take care of this issue.

full diff:

https://github.com/docker/libnetwork/compare/7dd202d11b2078c063fefc614c9fb9e4615da0e1...0ef1f8c94fa85acacf88b9be75ae07de91d0b2a5

which includes these changes:
* https://github.com/docker/libnetwork/pull/2052 [Backport 17.12] watchMiss fixes
* https://github.com/docker/libnetwork/pull/2059 [17.12] Enable IPV6 config on Sandbox creation on live-restore