### PR TITLE
[18.02] skip DockerTrustSuite tests for 18.02

### DIFF
--- a/components/engine/integration-cli/docker_cli_build_test.go
+++ b/components/engine/integration-cli/docker_cli_build_test.go
@@ -4228,6 +4228,7 @@ func (s *DockerTrustSuite) TestBuildContextDirIsSymlink(c *check.C) {
 }
 
 func (s *DockerTrustSuite) TestTrustedBuildTagFromReleasesRole(c *check.C) {
+	c.Skip("Blacklisting for Docker CE")
 	testRequires(c, NotaryHosting)
 
 	latestTag := s.setupTrustedImage(c, "trusted-build-releases-role")
@@ -4259,6 +4260,7 @@ func (s *DockerTrustSuite) TestTrustedBuildTagFromReleasesRole(c *check.C) {
 }
 
 func (s *DockerTrustSuite) TestTrustedBuildTagIgnoresOtherDelegationRoles(c *check.C) {
+	c.Skip("Blacklisting for Docker CE")
 	testRequires(c, NotaryHosting)
 
 	latestTag := s.setupTrustedImage(c, "trusted-build-releases-role")

--- a/components/engine/integration-cli/docker_cli_pull_trusted_test.go
+++ b/components/engine/integration-cli/docker_cli_pull_trusted_test.go
@@ -133,6 +133,7 @@ func (s *DockerTrustSuite) TestTrustedPullDelete(c *check.C) {
 }
 
 func (s *DockerTrustSuite) TestTrustedPullReadsFromReleasesRole(c *check.C) {
+	c.Skip("Blacklisting for Docker CE")
 	testRequires(c, NotaryHosting)
 	repoName := fmt.Sprintf("%v/dockerclireleasesdelegationpulling/trusted", privateRegistryURL)
 	targetName := fmt.Sprintf("%s:latest", repoName)
@@ -188,6 +189,7 @@ func (s *DockerTrustSuite) TestTrustedPullReadsFromReleasesRole(c *check.C) {
 }
 
 func (s *DockerTrustSuite) TestTrustedPullIgnoresOtherDelegationRoles(c *check.C) {
+	c.Skip("Blacklisting for Docker CE")
 	testRequires(c, NotaryHosting)
 	repoName := fmt.Sprintf("%v/dockerclipullotherdelegation/trusted", privateRegistryURL)
 	targetName := fmt.Sprintf("%s:latest", repoName)

--- a/components/engine/integration-cli/docker_cli_push_test.go
+++ b/components/engine/integration-cli/docker_cli_push_test.go
@@ -282,6 +282,7 @@ func (s *DockerSchema1RegistrySuite) TestCrossRepositoryLayerPushNotSupported(c 
 }
 
 func (s *DockerTrustSuite) TestTrustedPush(c *check.C) {
+	c.Skip("Blacklisting for Docker CE")
 	repoName := fmt.Sprintf("%v/dockerclitrusted/pushtest:latest", privateRegistryURL)
 	// tag the image and upload it to the private registry
 	cli.DockerCmd(c, "tag", "busybox", repoName)
@@ -366,6 +367,7 @@ func (s *DockerTrustSuite) TestTrustedPushWithExistingSignedTag(c *check.C) {
 }
 
 func (s *DockerTrustSuite) TestTrustedPushWithIncorrectPassphraseForNonRoot(c *check.C) {
+	c.Skip("Blacklisting for Docker CE")
 	repoName := fmt.Sprintf("%v/dockercliincorretpwd/trusted:latest", privateRegistryURL)
 	// tag the image and upload it to the private registry
 	cli.DockerCmd(c, "tag", "busybox", repoName)

--- a/components/engine/integration-cli/trust_server_test.go
+++ b/components/engine/integration-cli/trust_server_test.go
@@ -41,7 +41,7 @@ const notaryHost = "localhost:4443"
 const notaryURL = "https://" + notaryHost
 
 var SuccessTagging = icmd.Expected{
-	Out: "Tagging",
+	Err: "Tagging",
 }
 
 var SuccessSigningAndPushing = icmd.Expected{


### PR DESCRIPTION
Seeing [failures](https://jenkins.dockerproject.org/job/docker-ce/223/execution/node/1003/log/) in `DockerTrustSuite`: 

```
...
FAIL: docker_cli_build_test.go:4223: DockerTrustSuite.TestTrustedBuildTagFromReleasesRole
FAIL: docker_cli_build_test.go:4254: DockerTrustSuite.TestTrustedBuildTagIgnoresOtherDelegationRoles
FAIL: docker_cli_create_test.go:295: DockerTrustSuite.TestTrustedCreate
FAIL: docker_cli_create_test.go:331: DockerTrustSuite.TestTrustedCreateFromBadTrustServer
FAIL: docker_cli_create_test.go:321: DockerTrustSuite.TestTrustedIsolatedCreate
FAIL: docker_cli_pull_trusted_test.go:25: DockerTrustSuite.TestTrustedIsolatedPull
FAIL: docker_cli_pull_trusted_test.go:85: DockerTrustSuite.TestTrustedOfflinePull
FAIL: docker_cli_pull_trusted_test.go:14: DockerTrustSuite.TestTrustedPull
FAIL: docker_cli_pull_trusted_test.go:48: DockerTrustSuite.TestTrustedPullFromBadTrustServer
FAIL: docker_cli_pull_trusted_test.go:135: DockerTrustSuite.TestTrustedPullReadsFromReleasesRole
FAIL: docker_cli_push_test.go:284: DockerTrustSuite.TestTrustedPush
FAIL: docker_cli_push_test.go:368: DockerTrustSuite.TestTrustedPushWithIncorrectPassphraseForNonRoot
FAIL: docker_cli_run_test.go:3142: DockerTrustSuite.TestTrustedRun
FAIL: docker_cli_run_test.go:3171: DockerTrustSuite.TestTrustedRunFromBadTrustServer
...
OOPS: 20 passed, 14 FAILED
...
```

This PR will address it by ignoring those tests until they can be ported to the new testing thing.

This PR fixes the same notary mismatch issue from 17.10, 17.11, 17.12, and 18.01 caused by updated stderr output from docker/cli#636 Fix stdout and errors in image/trust

This pr is duplicate of #344 [17.12] update trust tests for 17.12

With cherry-pick e357107 and 5742bd3:
```
$ git cherry-pick -s -x e357107 5742bd3
```

No conflicts.