### PR TITLE
[17.12] Replace zesty repos with ones that work

### DIFF
--- a/components/packaging/deb/ubuntu-zesty/Dockerfile.aarch64
+++ b/components/packaging/deb/ubuntu-zesty/Dockerfile.aarch64
@@ -1,5 +1,7 @@
 FROM arm64v8/ubuntu:zesty
 
+RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com|ports.ubuntu.com\/ubuntu-ports/old-releases.ubuntu.com\/ubuntu/g' /etc/apt/sources.list
+
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev gnupg dirmngr  --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION 1.9.2

--- a/components/packaging/deb/ubuntu-zesty/Dockerfile.armv7l
+++ b/components/packaging/deb/ubuntu-zesty/Dockerfile.armv7l
@@ -1,5 +1,7 @@
 FROM arm32v7/ubuntu:zesty
 
+RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com|ports.ubuntu.com\/ubuntu-ports/old-releases.ubuntu.com\/ubuntu/g' /etc/apt/sources.list
+
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION 1.9.2

--- a/components/packaging/deb/ubuntu-zesty/Dockerfile.ppc64le
+++ b/components/packaging/deb/ubuntu-zesty/Dockerfile.ppc64le
@@ -1,5 +1,7 @@
 FROM ppc64le/ubuntu:zesty
 
+RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com|ports.ubuntu.com\/ubuntu-ports/old-releases.ubuntu.com\/ubuntu/g' /etc/apt/sources.list
+
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev pkg-config vim-common libseccomp-dev libsystemd-dev libltdl-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION 1.9.2

--- a/components/packaging/deb/ubuntu-zesty/Dockerfile.s390x
+++ b/components/packaging/deb/ubuntu-zesty/Dockerfile.s390x
@@ -1,5 +1,7 @@
 FROM s390x/ubuntu:zesty
 
+RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com|ports.ubuntu.com\/ubuntu-ports/old-releases.ubuntu.com\/ubuntu/g' /etc/apt/sources.list
+
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION 1.9.2

--- a/components/packaging/deb/ubuntu-zesty/Dockerfile.x86_64
+++ b/components/packaging/deb/ubuntu-zesty/Dockerfile.x86_64
@@ -1,5 +1,7 @@
 FROM ubuntu:zesty
 
+RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list
+
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION 1.9.2


### PR DESCRIPTION
Ubuntu Zesty recently reached its EOL, however we still support it for
Docker CE 17.12 so we need to make sure that we can still build on
Ubuntu Zesty.

All package repositories for Ubuntu Zesty have been moved to
old-releases.ubuntu.com.

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>