### PR TITLE
[18.02] Bump Go to 1.9.3

### DIFF
--- a/components/cli/dockerfiles/Dockerfile.cross
+++ b/components/cli/dockerfiles/Dockerfile.cross
@@ -1,3 +1,3 @@
-FROM    dockercore/golang-cross@sha256:2e843a0e4d82b6bab34d2cb7abe26d1a6cda23226ecc3869100c8db553603f9b
+FROM    dockercore/golang-cross:1.9.3@sha256:2ac6046dd738cf83a7557a9fc2be52accb97c103c5e9d2c2a50daa797c8eb79f
 ENV     DISABLE_WARN_OUTSIDE_CONTAINER=1
 WORKDIR /go/src/github.com/docker/cli

--- a/components/cli/dockerfiles/Dockerfile.dev
+++ b/components/cli/dockerfiles/Dockerfile.dev
@@ -1,5 +1,5 @@
 
-FROM    golang:1.9.2-alpine3.6
+FROM    golang:1.9.3-alpine3.6
 
 RUN     apk add -U git make bash coreutils ca-certificates
 

--- a/components/cli/dockerfiles/Dockerfile.lint
+++ b/components/cli/dockerfiles/Dockerfile.lint
@@ -1,4 +1,4 @@
-FROM    golang:1.9.2-alpine3.6
+FROM    golang:1.9.3-alpine3.6
 
 RUN     apk add -U git
 


### PR DESCRIPTION
cherry-pick of https://github.com/docker/cli/pull/827 for 18.02

```
git checkout -b 18.02-backport-bump-golang-1.9.3 upstream/18.02
git cherry-pick -s -S -x -Xsubtree=components/cli ffc76483226ee1528cab5cf8ea78c0824272cd58
```

no conflicts