### PR TITLE
[18.02] Annotate "stack" commands to be "swarm" and "kubernetes"

### DIFF
--- a/components/cli/cli/command/stack/cmd.go
+++ b/components/cli/cli/command/stack/cmd.go
@@ -9,11 +9,15 @@ import (
 // NewStackCommand returns a cobra command for `stack` subcommands
 func NewStackCommand(dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:         "stack",
-		Short:       "Manage Docker stacks",
-		Args:        cli.NoArgs,
-		RunE:        command.ShowHelp(dockerCli.Err()),
-		Annotations: map[string]string{"version": "1.25"},
+		Use:   "stack",
+		Short: "Manage Docker stacks",
+		Args:  cli.NoArgs,
+		RunE:  command.ShowHelp(dockerCli.Err()),
+		Annotations: map[string]string{
+			"kubernetes": "",
+			"swarm":      "",
+			"version":    "1.25",
+		},
 	}
 	cmd.AddCommand(
 		newDeployCommand(dockerCli),
@@ -37,6 +41,10 @@ func NewTopLevelDeployCommand(dockerCli command.Cli) *cobra.Command {
 	cmd := newDeployCommand(dockerCli)
 	// Remove the aliases at the top level
 	cmd.Aliases = []string{}
-	cmd.Annotations = map[string]string{"experimental": "", "version": "1.25"}
+	cmd.Annotations = map[string]string{
+		"experimental": "",
+		"swarm":        "",
+		"version":      "1.25",
+	}
 	return cmd
 }

--- a/components/cli/cmd/docker/docker.go
+++ b/components/cli/cmd/docker/docker.go
@@ -277,10 +277,12 @@ func areFlagsSupported(cmd *cobra.Command, details versionDetails) error {
 			if _, ok := f.Annotations["experimentalCLI"]; ok && !hasExperimentalCLI {
 				errs = append(errs, fmt.Sprintf("\"--%s\" is only supported when experimental cli features are enabled", f.Name))
 			}
-			if _, ok := f.Annotations["kubernetes"]; ok && !hasKubernetes {
+			_, isKubernetesAnnotated := f.Annotations["kubernetes"]
+			_, isSwarmAnnotated := f.Annotations["swarm"]
+			if isKubernetesAnnotated && !isSwarmAnnotated && !hasKubernetes {
 				errs = append(errs, fmt.Sprintf("\"--%s\" is only supported on a Docker cli with kubernetes features enabled", f.Name))
 			}
-			if _, ok := f.Annotations["swarm"]; ok && hasKubernetes {
+			if isSwarmAnnotated && !isKubernetesAnnotated && hasKubernetes {
 				errs = append(errs, fmt.Sprintf("\"--%s\" is only supported on a Docker cli with swarm features enabled", f.Name))
 			}
 		}
@@ -309,10 +311,13 @@ func areSubcommandsSupported(cmd *cobra.Command, details versionDetails) error {
 		if _, ok := curr.Annotations["experimentalCLI"]; ok && !hasExperimentalCLI {
 			return fmt.Errorf("%s is only supported when experimental cli features are enabled", cmd.CommandPath())
 		}
-		if _, ok := curr.Annotations["kubernetes"]; ok && !hasKubernetes {
+		_, isKubernetesAnnotated := curr.Annotations["kubernetes"]
+		_, isSwarmAnnotated := curr.Annotations["swarm"]
+
+		if isKubernetesAnnotated && !isSwarmAnnotated && !hasKubernetes {
 			return fmt.Errorf("%s is only supported on a Docker cli with kubernetes features enabled", cmd.CommandPath())
 		}
-		if _, ok := curr.Annotations["swarm"]; ok && hasKubernetes {
+		if isSwarmAnnotated && !isKubernetesAnnotated && hasKubernetes {
 			return fmt.Errorf("%s is only supported on a Docker cli with swarm features enabled", cmd.CommandPath())
 		}
 	}


### PR DESCRIPTION
backport:
* https://github.com/docker/cli/pull/804 Annotate "stack" commands to be "swarm" and "kubernetes"

with cherry-pick of git commit https://github.com/docker/cli/pull/804/commits/93c36eb228f6e85b68dbddd374fc7ed0b07ab28d:
```
$ git cherry-pick -s -x -Xsubtree=component/cli 93c36eb
```

no conflicts