### PR TITLE
[18.02] Using Flags instead of PersistentFlags, as Kubernetes flags seem not …

### DIFF
--- a/components/cli/cli/command/stack/kubernetes/cli.go
+++ b/components/cli/cli/command/stack/kubernetes/cli.go
@@ -27,15 +27,15 @@ func WrapCli(dockerCli command.Cli, cmd *cobra.Command) (*KubeCli, error) {
 		Cli:           dockerCli,
 		kubeNamespace: "default",
 	}
-	if cmd.PersistentFlags().Changed("namespace") {
-		cli.kubeNamespace, err = cmd.PersistentFlags().GetString("namespace")
+	if cmd.Flags().Changed("namespace") {
+		cli.kubeNamespace, err = cmd.Flags().GetString("namespace")
 		if err != nil {
 			return nil, err
 		}
 	}
 	kubeConfig := ""
-	if cmd.PersistentFlags().Changed("kubeconfig") {
-		kubeConfig, err = cmd.PersistentFlags().GetString("kubeconfig")
+	if cmd.Flags().Changed("kubeconfig") {
+		kubeConfig, err = cmd.Flags().GetString("kubeconfig")
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
backport:
* https://github.com/docker/cli/pull/831 Fix broken Kubernetes stack flags

with cherry-pick of git commit https://github.com/docker/cli/pull/831/commits/14fcadffb137eb673f66669c3f30d7e289553d69:
```
$ git cherry-pick -s -x -Xsubtree=component/cli 14fcadf
```

no conflicts