### PR TITLE
[17.12] Refresh containerd remotes on containerd restarted

### DIFF
--- a/components/engine/libcontainerd/remote_daemon.go
+++ b/components/engine/libcontainerd/remote_daemon.go
@@ -278,7 +278,7 @@ func (r *remote) monitorConnection(client *containerd.Client) {
 
 		select {
 		case <-r.shutdownContext.Done():
-			r.logger.Info("stopping healtcheck following graceful shutdown")
+			r.logger.Info("stopping healthcheck following graceful shutdown")
 			client.Close()
 			return
 		default:


### PR DESCRIPTION
Cherry-pick of https://github.com/moby/moby/pull/36173 for 17.12. Also includes https://github.com/moby/moby/pull/35768 (which is just a typo fix) to get a clean cherry-pick

```
git checkout -b 17.12-backport-fix_containerd_crash_spin upstream/17.12
git cherry-pick -s -S -x -Xsubtree=components/engine 5c3418e38b9603e8ff582d53c2face57f0f01cce
git cherry-pick -s -S -x -Xsubtree=components/engine 400126f8698233099259da967378c0a76bc3ea31
```

no conflicts


Before this patch, when containerd is restarted (due to a crash, or
kill, whatever), the daemon would keep trying to process the event
stream against the old socket handles. This would lead to a CPU spin due
to the error handling when the client can't connect to containerd.

This change makes sure the containerd remote client is updated for all
registered libcontainerd clients.

This is not neccessarily the ideal fix which would likely require a
major refactor, but at least gets things to a working state with a
minimal patch.

fixes https://github.com/moby/moby/issues/36002 for 17.12