### PR TITLE
[17.12] Add `REMOVE` and `ORPHANED` to TaskState

### DIFF
--- a/components/engine/api/swagger.yaml
+++ b/components/engine/api/swagger.yaml
@@ -2788,6 +2788,8 @@ definitions:
       - "shutdown"
       - "failed"
       - "rejected"
+      - "remove"
+      - "orphaned"
 
   Task:
     type: "object"

--- a/components/engine/api/types/swarm/task.go
+++ b/components/engine/api/types/swarm/task.go
@@ -36,6 +36,10 @@ const (
 	TaskStateFailed TaskState = "failed"
 	// TaskStateRejected REJECTED
 	TaskStateRejected TaskState = "rejected"
+	// TaskStateRemove REMOVE
+	TaskStateRemove TaskState = "remove"
+	// TaskStateOrphaned ORPHANED
+	TaskStateOrphaned TaskState = "orphaned"
 )
 
 // Task represents a task.


### PR DESCRIPTION
back port of https://github.com/moby/moby/pull/36146 for 17.12

```
git checkout -b 17.12-backport-36142-TaskState upstream/17.12
git cherry-pick -s -S -x -Xsubtree=components/engine a40687f5ac7df27bc6c6c3a6f69513a397a1a05a
```

no conclicts

This fix tries to address the issue raised in 36142 where
there are discrepancies between Swarm API and swagger.yaml.

This fix adds two recently added state `REMOVE` and `ORPHANED` to TaskState.

This fix fixes 36142.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
(cherry picked from commit a40687f5ac7df27bc6c6c3a6f69513a397a1a05a)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>