### PR TITLE
[17.12] Fix issue where network inspect does not show Created time in swarm scope

### DIFF
--- a/components/engine/daemon/cluster/convert/network.go
+++ b/components/engine/daemon/cluster/convert/network.go
@@ -168,6 +168,7 @@ func BasicNetworkFromGRPC(n swarmapi.Network) basictypes.NetworkResource {
 		Ingress:    IsIngressNetwork(&n),
 		Labels:     n.Spec.Annotations.Labels,
 	}
+	nr.Created, _ = gogotypes.TimestampFromProto(n.Meta.CreatedAt)
 
 	if n.Spec.GetNetwork() != "" {
 		nr.ConfigFrom = networktypes.ConfigReference{

--- a/components/engine/daemon/cluster/convert/network_test.go
+++ b/components/engine/daemon/cluster/convert/network_test.go
@@ -1,0 +1,34 @@
+package convert
+
+import (
+	"testing"
+	"time"
+
+	swarmapi "github.com/docker/swarmkit/api"
+	gogotypes "github.com/gogo/protobuf/types"
+)
+
+func TestNetworkConvertBasicNetworkFromGRPCCreatedAt(t *testing.T) {
+	expected, err := time.Parse("Jan 2, 2006 at 3:04pm (MST)", "Jan 10, 2018 at 7:54pm (PST)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	createdAt, err := gogotypes.TimestampProto(expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nw := swarmapi.Network{
+		Meta: swarmapi.Meta{
+			Version: swarmapi.Version{
+				Index: 1,
+			},
+			CreatedAt: createdAt,
+		},
+	}
+
+	n := BasicNetworkFromGRPC(nw)
+	if !n.Created.Equal(expected) {
+		t.Fatalf("expected time %s; received %s", expected, n.Created)
+	}
+}


### PR DESCRIPTION
Backport of https://github.com/moby/moby/pull/36095 for 17.12

```
git checkout -b 17.12-backport-36083-network-inspect-created-time upstream/17.12
git cherry-pick -s -S -x -Xsubtree=components/engine 090c439fb8a863731cc80fcb9932ce5958d8166d
```

(no conflicts)

This fix tries to address the issue raised in 36083 where
`network inspect` does not show Created time if the network is
created in swarm scope.

The issue was that Created was not converted from swarm api.
This fix addresses the issue.

An unit test has been added.

This fix fixes 36083.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
(cherry picked from commit 090c439fb8a863731cc80fcb9932ce5958d8166d)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

Please do not send pull requests to this docker/docker-ce repository.

We do, however, take contributions gladly.

See https://github.com/docker/docker-ce/blob/master/CONTRIBUTING.md

Thanks!
