### PR TITLE
Fix to address regression caused by PR 30897

### DIFF
--- a/components/engine/daemon/network.go
+++ b/components/engine/daemon/network.go
@@ -267,9 +267,9 @@ func (daemon *Daemon) CreateNetwork(create types.NetworkCreateRequest) (*types.N
 }
 
 func (daemon *Daemon) createNetwork(create types.NetworkCreateRequest, id string, agent bool) (*types.NetworkCreateResponse, error) {
-	if runconfig.IsPreDefinedNetwork(create.Name) && !agent {
-		err := fmt.Errorf("%s is a pre-defined network and cannot be created", create.Name)
-		return nil, errdefs.Forbidden(err)
+	if runconfig.IsPreDefinedNetwork(create.Name) {
+		logrus.Debugf("%s is a pre-defined network and cannot be created \n", create.Name)
+		return nil, libnetwork.NetworkNameError(create.Name)
 	}
 
 	var warning string


### PR DESCRIPTION
 With the inclusion of PR 30897, creating service for host network
fails in 18.02. Modified IsPreDefinedNetwork check and return
NetworkNameError instead of errdefs.Forbidden to address this issue

Signed-off-by: selansen <elango.siva@docker.com>

Please do not send pull requests to this docker/docker-ce repository.

We do, however, take contributions gladly.

See https://github.com/docker/docker-ce/blob/master/CONTRIBUTING.md

Thanks!
