### PR TITLE
[17.12] backport layer not retained

### DIFF
--- a/components/engine/daemon/changes.go
+++ b/components/engine/daemon/changes.go
@@ -22,6 +22,9 @@ func (daemon *Daemon) ContainerChanges(name string) ([]archive.Change, error) {
 
 	container.Lock()
 	defer container.Unlock()
+	if container.RWLayer == nil {
+		return nil, errors.New("RWLayer of container " + name + " is unexpectedly nil")
+	}
 	c, err := container.RWLayer.Changes()
 	if err != nil {
 		return nil, err

--- a/components/engine/daemon/daemon.go
+++ b/components/engine/daemon/daemon.go
@@ -1056,6 +1056,9 @@ func (daemon *Daemon) Shutdown() error {
 // Mount sets container.BaseFS
 // (is it not set coming in? why is it unset?)
 func (daemon *Daemon) Mount(container *container.Container) error {
+	if container.RWLayer == nil {
+		return errors.New("RWLayer of container " + container.ID + " is unexpectedly nil")
+	}
 	dir, err := container.RWLayer.Mount(container.GetMountLabel())
 	if err != nil {
 		return err
@@ -1078,6 +1081,9 @@ func (daemon *Daemon) Mount(container *container.Container) error {
 
 // Unmount unsets the container base filesystem
 func (daemon *Daemon) Unmount(container *container.Container) error {
+	if container.RWLayer == nil {
+		return errors.New("RWLayer of container " + container.ID + " is unexpectedly nil")
+	}
 	if err := container.RWLayer.Unmount(); err != nil {
 		logrus.Errorf("Error unmounting container %s: %s", container.ID, err)
 		return err

--- a/components/engine/daemon/delete.go
+++ b/components/engine/daemon/delete.go
@@ -124,6 +124,7 @@ func (daemon *Daemon) cleanupContainer(container *container.Container, forceRemo
 			container.SetRemovalError(e)
 			return e
 		}
+		container.RWLayer = nil
 	}
 
 	if err := system.EnsureRemoveAll(container.Root); err != nil {

--- a/components/engine/daemon/inspect_test.go
+++ b/components/engine/daemon/inspect_test.go
@@ -1,0 +1,33 @@
+package daemon // import "github.com/docker/docker/daemon"
+
+import (
+	"testing"
+
+	containertypes "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/container"
+	"github.com/docker/docker/daemon/config"
+	"github.com/docker/docker/daemon/exec"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetInspectData(t *testing.T) {
+	c := &container.Container{
+		ID:           "inspect-me",
+		HostConfig:   &containertypes.HostConfig{},
+		State:        container.NewState(),
+		ExecCommands: exec.NewStore(),
+	}
+
+	d := &Daemon{
+		linkIndex:   newLinkIndex(),
+		configStore: &config.Config{},
+	}
+
+	_, err := d.getInspectData(c)
+	assert.Error(t, err)
+
+	c.Dead = true
+	_, err = d.getInspectData(c)
+	assert.NoError(t, err)
+}

--- a/components/engine/daemon/oci_windows.go
+++ b/components/engine/daemon/oci_windows.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -144,6 +145,9 @@ func (daemon *Daemon) createSpec(c *container.Container) (*specs.Spec, error) {
 		}
 		// Reverse order, expecting parent most first
 		s.Windows.LayerFolders = append([]string{layerPath}, s.Windows.LayerFolders...)
+	}
+	if c.RWLayer == nil {
+		return nil, errors.New("RWLayer of container " + c.ID + " is unexpectedly nil")
 	}
 	m, err := c.RWLayer.Metadata()
 	if err != nil {


### PR DESCRIPTION
*(this is a replacement for https://github.com/docker/docker-ce/pull/424)*

back port of moby/moby#36160 and moby/moby#36242 for 17.12
```
git checkout -b 17.12-backport-layer-not-retained upstream/17.12
git cherry-pick -s -S -x -Xsubtree=components/engine e9b9e4ace294230c6b8eb010eda564a2541c4564
git cherry-pick -s -S -x -Xsubtree=components/engine 195893d38160c0893e326b8674e05ef6714aeaa4
```

Second commit is modified to use `systemError` instead of `errdefs.System(err)` (as https://github.com/moby/moby/commit/87a12421a94faac294079bebc97c8abb4180dde5 is not backported).
