### PR TITLE
[17.12] bump containerd 1.0.2

### DIFF
--- a/components/engine/hack/dockerfile/binaries-commits
+++ b/components/engine/hack/dockerfile/binaries-commits
@@ -3,8 +3,12 @@
 TOMLV_COMMIT=9baf8a8a9f2ed20a8e54160840c492f937eeaf9a
 
 # When updating RUNC_COMMIT, also update runc in vendor.conf accordingly
-RUNC_COMMIT=9f9c96235cc97674e935002fc3d78361b696a69e
-CONTAINERD_COMMIT=9b55aab90508bd389d7654c4baf173a981477d55 # v1.0.1
+RUNC_COMMIT=6c55f98695e902427906eed2c799e566e3d3dfb5
+
+# containerd is also pinned in vendor.conf. When updating the binary
+# version you may also need to update the vendor version to pick up bug
+# fixes or new APIs.
+CONTAINERD_COMMIT=cfd04396dc68220d1cecbe686a6cc3aa5ce3667c # v1.0.2
 TINI_COMMIT=949e6facb77383876aeff8a6944dde66b3089574
 LIBNETWORK_COMMIT=7b2b1feb1de4817d522cc372af149ff48d25028e
 VNDR_COMMIT=a6e196d8b4b0cbbdc29aebdb20c59ac6926bb384

--- a/components/engine/libcontainerd/remote_daemon_options_linux.go
+++ b/components/engine/libcontainerd/remote_daemon_options_linux.go
@@ -16,19 +16,3 @@ func (o oomScore) Apply(r Remote) error {
 	}
 	return fmt.Errorf("WithOOMScore option not supported for this remote")
 }
-
-// WithSubreaper sets whether containerd should register itself as a
-// subreaper
-func WithSubreaper(reap bool) RemoteOption {
-	return subreaper(reap)
-}
-
-type subreaper bool
-
-func (s subreaper) Apply(r Remote) error {
-	if remote, ok := r.(*remote); ok {
-		remote.NoSubreaper = !bool(s)
-		return nil
-	}
-	return fmt.Errorf("WithSubreaper option not supported for this remote")
-}

--- a/components/engine/vendor.conf
+++ b/components/engine/vendor.conf
@@ -104,15 +104,15 @@ github.com/googleapis/gax-go da06d194a00e19ce00d9011a13931c3f6f6887c7
 google.golang.org/genproto d80a6e20e776b0b17a324d0ba1ab50a39c8e8944
 
 # containerd
-github.com/containerd/containerd 89623f28b87a6004d4b785663257362d1658a729 # v1.0.0
+github.com/containerd/containerd cfd04396dc68220d1cecbe686a6cc3aa5ce3667c # v1.0.2
 github.com/containerd/fifo fbfb6a11ec671efbe94ad1c12c2e98773f19e1e6
 github.com/containerd/continuity 35d55c5e8dd23b32037d56cf97174aff3efdfa83
-github.com/containerd/cgroups 29da22c6171a4316169f9205ab6c49f59b5b852f
+github.com/containerd/cgroups c0710c92e8b3a44681d1321dcfd1360fc5c6c089
 github.com/containerd/console 84eeaae905fa414d03e07bcd6c8d3f19e7cf180e
-github.com/containerd/go-runc ed1cbe1fc31f5fb2359d3a54b6330d1a097858b7
+github.com/containerd/go-runc 4f6e87ae043f859a38255247b49c9abc262d002f
 github.com/containerd/typeurl f6943554a7e7e88b3c14aad190bf05932da84788
 github.com/dmcgowan/go-tar go1.10
-github.com/stevvooe/ttrpc 76e68349ad9ab4d03d764c713826d31216715e4f
+github.com/stevvooe/ttrpc d4528379866b0ce7e9d71f3eb96f0582fc374577
 
 # cluster
 github.com/docker/swarmkit 7598f7a937de4ad0a856012bd548009ceeb0d10e

--- a/components/engine/vendor/github.com/containerd/cgroups/errors.go
+++ b/components/engine/vendor/github.com/containerd/cgroups/errors.go
@@ -12,7 +12,7 @@ var (
 	ErrFreezerNotSupported      = errors.New("cgroups: freezer cgroup not supported on this system")
 	ErrMemoryNotSupported       = errors.New("cgroups: memory cgroup not supported on this system")
 	ErrCgroupDeleted            = errors.New("cgroups: cgroup deleted")
-	ErrNoCgroupMountDestination = errors.New("cgroups: cannot found cgroup mount destination")
+	ErrNoCgroupMountDestination = errors.New("cgroups: cannot find cgroup mount destination")
 )
 
 // ErrorHandler is a function that handles and acts on errors

--- a/components/engine/vendor/github.com/containerd/containerd/archive/tar.go
+++ b/components/engine/vendor/github.com/containerd/containerd/archive/tar.go
@@ -19,12 +19,14 @@ import (
 	"github.com/pkg/errors"
 )
 
-var bufferPool = &sync.Pool{
+var bufPool = &sync.Pool{
 	New: func() interface{} {
 		buffer := make([]byte, 32*1024)
 		return &buffer
 	},
 }
+
+var errInvalidArchive = errors.New("invalid archive")
 
 // Diff returns a tar stream of the computed filesystem
 // difference between the provided directories.
@@ -220,6 +222,15 @@ func Apply(ctx context.Context, root string, r io.Reader) (int64, error) {
 
 			originalBase := base[len(whiteoutPrefix):]
 			originalPath := filepath.Join(dir, originalBase)
+
+			// Ensure originalPath is under dir
+			if dir[len(dir)-1] != filepath.Separator {
+				dir += string(filepath.Separator)
+			}
+			if !strings.HasPrefix(originalPath, dir) {
+				return 0, errors.Wrapf(errInvalidArchive, "invalid whiteout name: %v", base)
+			}
+
 			if err := os.RemoveAll(originalPath); err != nil {
 				return 0, err
 			}
@@ -291,6 +302,7 @@ type changeWriter struct {
 	whiteoutT time.Time
 	inodeSrc  map[uint64]string
 	inodeRefs map[uint64][]string
+	addedDirs map[string]struct{}
 }
 
 func newChangeWriter(w io.Writer, source string) *changeWriter {
@@ -300,6 +312,7 @@ func newChangeWriter(w io.Writer, source string) *changeWriter {
 		whiteoutT: time.Now(),
 		inodeSrc:  map[uint64]string{},
 		inodeRefs: map[uint64][]string{},
+		addedDirs: map[string]struct{}{},
 	}
 }
 
@@ -312,11 +325,15 @@ func (cw *changeWriter) HandleChange(k fs.ChangeKind, p string, f os.FileInfo, e
 		whiteOutBase := filepath.Base(p)
 		whiteOut := filepath.Join(whiteOutDir, whiteoutPrefix+whiteOutBase)
 		hdr := &tar.Header{
+			Typeflag:   tar.TypeReg,
 			Name:       whiteOut[1:],
 			Size:       0,
 			ModTime:    cw.whiteoutT,
 			AccessTime: cw.whiteoutT,
 			ChangeTime: cw.whiteoutT,
+		}
+		if err := cw.includeParents(hdr); err != nil {
+			return err
 		}
 		if err := cw.tw.WriteHeader(hdr); err != nil {
 			return errors.Wrap(err, "failed to write whiteout header")
@@ -395,6 +412,9 @@ func (cw *changeWriter) HandleChange(k fs.ChangeKind, p string, f os.FileInfo, e
 			hdr.PAXRecords[paxSchilyXattr+"security.capability"] = string(capability)
 		}
 
+		if err := cw.includeParents(hdr); err != nil {
+			return err
+		}
 		if err := cw.tw.WriteHeader(hdr); err != nil {
 			return errors.Wrap(err, "failed to write file header")
 		}
@@ -406,9 +426,7 @@ func (cw *changeWriter) HandleChange(k fs.ChangeKind, p string, f os.FileInfo, e
 			}
 			defer file.Close()
 
-			buf := bufferPool.Get().(*[]byte)
-			n, err := io.CopyBuffer(cw.tw, file, *buf)
-			bufferPool.Put(buf)
+			n, err := copyBuffered(context.TODO(), cw.tw, file)
 			if err != nil {
 				return errors.Wrap(err, "failed to copy")
 			}
@@ -424,6 +442,10 @@ func (cw *changeWriter) HandleChange(k fs.ChangeKind, p string, f os.FileInfo, e
 				hdr.Typeflag = tar.TypeLink
 				hdr.Linkname = source
 				hdr.Size = 0
+
+				if err := cw.includeParents(hdr); err != nil {
+					return err
+				}
 				if err := cw.tw.WriteHeader(hdr); err != nil {
 					return errors.Wrap(err, "failed to write file header")
 				}
@@ -533,9 +555,35 @@ func createTarFile(ctx context.Context, path, extractDir string, hdr *tar.Header
 	return chtimes(path, boundTime(latestTime(hdr.AccessTime, hdr.ModTime)), boundTime(hdr.ModTime))
 }
 
+func (cw *changeWriter) includeParents(hdr *tar.Header) error {
+	name := strings.TrimRight(hdr.Name, "/")
+	fname := filepath.Join(cw.source, name)
+	parent := filepath.Dir(name)
+	pname := filepath.Join(cw.source, parent)
+
+	// Do not include root directory as parent
+	if fname != cw.source && pname != cw.source {
+		_, ok := cw.addedDirs[parent]
+		if !ok {
+			cw.addedDirs[parent] = struct{}{}
+			fi, err := os.Stat(pname)
+			if err != nil {
+				return err
+			}
+			if err := cw.HandleChange(fs.ChangeKindModify, parent, fi, nil); err != nil {
+				return err
+			}
+		}
+	}
+	if hdr.Typeflag == tar.TypeDir {
+		cw.addedDirs[name] = struct{}{}
+	}
+	return nil
+}
+
 func copyBuffered(ctx context.Context, dst io.Writer, src io.Reader) (written int64, err error) {
-	buf := bufferPool.Get().(*[]byte)
-	defer bufferPool.Put(buf)
+	buf := bufPool.Get().(*[]byte)
+	defer bufPool.Put(buf)
 
 	for {
 		select {

--- a/components/engine/vendor/github.com/containerd/containerd/cio/io.go
+++ b/components/engine/vendor/github.com/containerd/containerd/cio/io.go
@@ -8,7 +8,14 @@ import (
 	"sync"
 )
 
-// Config holds the io configurations.
+var bufPool = sync.Pool{
+	New: func() interface{} {
+		buffer := make([]byte, 32<<10)
+		return &buffer
+	},
+}
+
+// Config holds the IO configurations.
 type Config struct {
 	// Terminal is true if one has been allocated
 	Terminal bool

--- a/components/engine/vendor/github.com/containerd/containerd/cio/io_windows.go
+++ b/components/engine/vendor/github.com/containerd/containerd/cio/io_windows.go
@@ -46,7 +46,11 @@ func copyIO(fifos *FIFOSet, ioset *ioSet, tty bool) (_ *wgCloser, err error) {
 				log.L.WithError(err).Errorf("failed to accept stdin connection on %s", fifos.In)
 				return
 			}
-			io.Copy(c, ioset.in)
+
+			p := bufPool.Get().(*[]byte)
+			defer bufPool.Put(p)
+
+			io.CopyBuffer(c, ioset.in, *p)
 			c.Close()
 			l.Close()
 		}()
@@ -72,7 +76,10 @@ func copyIO(fifos *FIFOSet, ioset *ioSet, tty bool) (_ *wgCloser, err error) {
 				log.L.WithError(err).Errorf("failed to accept stdout connection on %s", fifos.Out)
 				return
 			}
-			io.Copy(ioset.out, c)
+			p := bufPool.Get().(*[]byte)
+			defer bufPool.Put(p)
+
+			io.CopyBuffer(ioset.out, c, *p)
 			c.Close()
 			l.Close()
 		}()
@@ -98,7 +105,10 @@ func copyIO(fifos *FIFOSet, ioset *ioSet, tty bool) (_ *wgCloser, err error) {
 				log.L.WithError(err).Errorf("failed to accept stderr connection on %s", fifos.Err)
 				return
 			}
-			io.Copy(ioset.err, c)
+			p := bufPool.Get().(*[]byte)
+			defer bufPool.Put(p)
+
+			io.CopyBuffer(ioset.err, c, *p)
 			c.Close()
 			l.Close()
 		}()

--- a/components/engine/vendor/github.com/containerd/containerd/content/helpers.go
+++ b/components/engine/vendor/github.com/containerd/containerd/content/helpers.go
@@ -3,6 +3,7 @@ package content
 import (
 	"context"
 	"io"
+	"io/ioutil"
 	"sync"
 
 	"github.com/containerd/containerd/errdefs"
@@ -76,14 +77,7 @@ func Copy(ctx context.Context, cw Writer, r io.Reader, size int64, expected dige
 	if ws.Offset > 0 {
 		r, err = seekReader(r, ws.Offset, size)
 		if err != nil {
-			if !isUnseekable(err) {
-				return errors.Wrapf(err, "unabled to resume write to %v", ws.Ref)
-			}
-
-			// reader is unseekable, try to move the writer back to the start.
-			if err := cw.Truncate(0); err != nil {
-				return errors.Wrapf(err, "content writer truncate failed")
-			}
+			return errors.Wrapf(err, "unable to resume write to %v", ws.Ref)
 		}
 	}
 
@@ -103,14 +97,9 @@ func Copy(ctx context.Context, cw Writer, r io.Reader, size int64, expected dige
 	return nil
 }
 
-var errUnseekable = errors.New("seek not supported")
-
-func isUnseekable(err error) bool {
-	return errors.Cause(err) == errUnseekable
-}
-
 // seekReader attempts to seek the reader to the given offset, either by
-// resolving `io.Seeker` or by detecting `io.ReaderAt`.
+// resolving `io.Seeker`, by detecting `io.ReaderAt`, or discarding
+// up to the given offset.
 func seekReader(r io.Reader, offset, size int64) (io.Reader, error) {
 	// attempt to resolve r as a seeker and setup the offset.
 	seeker, ok := r.(io.Seeker)
@@ -134,5 +123,17 @@ func seekReader(r io.Reader, offset, size int64) (io.Reader, error) {
 		return sr, nil
 	}
 
-	return r, errors.Wrapf(errUnseekable, "seek to offset %v failed", offset)
+	// well then, let's just discard up to the offset
+	buf := bufPool.Get().(*[]byte)
+	defer bufPool.Put(buf)
+
+	n, err := io.CopyBuffer(ioutil.Discard, io.LimitReader(r, offset), *buf)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to discard to offset")
+	}
+	if n != offset {
+		return nil, errors.Errorf("unable to discard to offset")
+	}
+
+	return r, nil
 }

--- a/components/engine/vendor/github.com/containerd/containerd/content/local/writer.go
+++ b/components/engine/vendor/github.com/containerd/containerd/content/local/writer.go
@@ -2,6 +2,7 @@ package local
 
 import (
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -167,5 +168,8 @@ func (w *writer) Truncate(size int64) error {
 	}
 	w.offset = 0
 	w.digester.Hash().Reset()
+	if _, err := w.fp.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
 	return w.fp.Truncate(0)
 }

--- a/components/engine/vendor/github.com/containerd/containerd/dialer/dialer.go
+++ b/components/engine/vendor/github.com/containerd/containerd/dialer/dialer.go
@@ -42,7 +42,7 @@ func Dialer(address string, timeout time.Duration) (net.Conn, error) {
 		close(stopC)
 		go func() {
 			dr := <-synC
-			if dr != nil {
+			if dr != nil && dr.c != nil {
 				dr.c.Close()
 			}
 		}()

--- a/components/engine/vendor/github.com/containerd/containerd/fs/diff.go
+++ b/components/engine/vendor/github.com/containerd/containerd/fs/diff.go
@@ -222,10 +222,8 @@ func doubleWalkDiff(ctx context.Context, changeFn ChangeFunc, a, b string) (err 
 		c1 = make(chan *currentPath)
 		c2 = make(chan *currentPath)
 
-		f1, f2         *currentPath
-		rmdir          string
-		lastEmittedDir = string(filepath.Separator)
-		parents        []os.FileInfo
+		f1, f2 *currentPath
+		rmdir  string
 	)
 	g.Go(func() error {
 		defer close(c1)
@@ -260,10 +258,7 @@ func doubleWalkDiff(ctx context.Context, changeFn ChangeFunc, a, b string) (err 
 				continue
 			}
 
-			var (
-				f    os.FileInfo
-				emit = true
-			)
+			var f os.FileInfo
 			k, p := pathChange(f1, f2)
 			switch k {
 			case ChangeKindAdd:
@@ -278,7 +273,7 @@ func doubleWalkDiff(ctx context.Context, changeFn ChangeFunc, a, b string) (err 
 				if rmdir != "" && strings.HasPrefix(f1.path, rmdir) {
 					f1 = nil
 					continue
-				} else if rmdir == "" && f1.f.IsDir() {
+				} else if f1.f.IsDir() {
 					rmdir = f1.path + string(os.PathSeparator)
 				} else if rmdir != "" {
 					rmdir = ""
@@ -299,83 +294,17 @@ func doubleWalkDiff(ctx context.Context, changeFn ChangeFunc, a, b string) (err 
 				f2 = nil
 				if same {
 					if !isLinked(f) {
-						emit = false
+						continue
 					}
 					k = ChangeKindUnmodified
 				}
 			}
-			if emit {
-				emittedDir, emitParents := commonParents(lastEmittedDir, p, parents)
-				for _, pf := range emitParents {
-					p := filepath.Join(emittedDir, pf.Name())
-					if err := changeFn(ChangeKindUnmodified, p, pf, nil); err != nil {
-						return err
-					}
-					emittedDir = p
-				}
-
-				if err := changeFn(k, p, f, nil); err != nil {
-					return err
-				}
-
-				if f != nil && f.IsDir() {
-					lastEmittedDir = p
-				} else {
-					lastEmittedDir = emittedDir
-				}
-
-				parents = parents[:0]
-			} else if f.IsDir() {
-				lastEmittedDir, parents = commonParents(lastEmittedDir, p, parents)
-				parents = append(parents, f)
+			if err := changeFn(k, p, f, nil); err != nil {
+				return err
 			}
 		}
 		return nil
 	})
 
 	return g.Wait()
-}
-
-func commonParents(base, updated string, dirs []os.FileInfo) (string, []os.FileInfo) {
-	if basePrefix := makePrefix(base); strings.HasPrefix(updated, basePrefix) {
-		var (
-			parents []os.FileInfo
-			last    = base
-		)
-		for _, d := range dirs {
-			next := filepath.Join(last, d.Name())
-			if strings.HasPrefix(updated, makePrefix(last)) {
-				parents = append(parents, d)
-				last = next
-			} else {
-				break
-			}
-		}
-		return base, parents
-	}
-
-	baseS := strings.Split(base, string(filepath.Separator))
-	updatedS := strings.Split(updated, string(filepath.Separator))
-	commonS := []string{string(filepath.Separator)}
-
-	min := len(baseS)
-	if len(updatedS) < min {
-		min = len(updatedS)
-	}
-	for i := 0; i < min; i++ {
-		if baseS[i] == updatedS[i] {
-			commonS = append(commonS, baseS[i])
-		} else {
-			break
-		}
-	}
-
-	return filepath.Join(commonS...), []os.FileInfo{}
-}
-
-func makePrefix(d string) string {
-	if d == "" || d[len(d)-1] != filepath.Separator {
-		return d + string(filepath.Separator)
-	}
-	return d
 }

--- a/components/engine/vendor/github.com/containerd/containerd/linux/proc/utils.go
+++ b/components/engine/vendor/github.com/containerd/containerd/linux/proc/utils.go
@@ -66,7 +66,10 @@ func copyFile(to, from string) error {
 		return err
 	}
 	defer tt.Close()
-	_, err = io.Copy(tt, ff)
+
+	p := bufPool.Get().(*[]byte)
+	defer bufPool.Put(p)
+	_, err = io.CopyBuffer(tt, ff, *p)
 	return err
 }
 

--- a/components/engine/vendor/github.com/containerd/containerd/linux/runtime.go
+++ b/components/engine/vendor/github.com/containerd/containerd/linux/runtime.go
@@ -26,9 +26,7 @@ import (
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/plugin"
-	"github.com/containerd/containerd/reaper"
 	"github.com/containerd/containerd/runtime"
-	"github.com/containerd/containerd/sys"
 	runc "github.com/containerd/go-runc"
 	"github.com/containerd/typeurl"
 	ptypes "github.com/gogo/protobuf/types"
@@ -159,9 +157,6 @@ func (r *Runtime) Create(ctx context.Context, id string, opts runtime.CreateOpts
 		return nil, err
 	}
 
-	ec := reaper.Default.Subscribe()
-	defer reaper.Default.Unsubscribe(ec)
-
 	bundle, err := newBundle(id,
 		filepath.Join(r.state, namespace),
 		filepath.Join(r.root, namespace),
@@ -206,10 +201,7 @@ func (r *Runtime) Create(ctx context.Context, id string, opts runtime.CreateOpts
 				"id":        id,
 				"namespace": namespace,
 			}).Warn("cleaning up after killed shim")
-			err = r.cleanupAfterDeadShim(context.Background(), bundle, namespace, id, lc.pid, ec)
-			if err == nil {
-				r.tasks.Delete(ctx, lc)
-			} else {
+			if err = r.cleanupAfterDeadShim(context.Background(), bundle, namespace, id, lc.pid); err != nil {
 				log.G(ctx).WithError(err).WithFields(logrus.Fields{
 					"id":        id,
 					"namespace": namespace,
@@ -313,12 +305,12 @@ func (r *Runtime) Delete(ctx context.Context, c runtime.Task) (*runtime.Exit, er
 
 	rsp, err := lc.shim.Delete(ctx, empty)
 	if err != nil {
-		if cerr := r.cleanupAfterDeadShim(ctx, bundle, namespace, c.ID(), lc.pid, nil); cerr != nil {
+		if cerr := r.cleanupAfterDeadShim(ctx, bundle, namespace, c.ID(), lc.pid); cerr != nil {
 			log.G(ctx).WithError(err).Error("unable to cleanup task")
 		}
 		return nil, errdefs.FromGRPC(err)
 	}
-	r.tasks.Delete(ctx, lc)
+	r.tasks.Delete(ctx, lc.id)
 	if err := lc.shim.KillShim(ctx); err != nil {
 		log.G(ctx).WithError(err).Error("failed to kill shim")
 	}
@@ -388,13 +380,23 @@ func (r *Runtime) loadTasks(ctx context.Context, ns string) ([]*Task, error) {
 		)
 		ctx = namespaces.WithNamespace(ctx, ns)
 		pid, _ := runc.ReadPidFile(filepath.Join(bundle.path, proc.InitPidFile))
-		s, err := bundle.NewShimClient(ctx, ns, ShimConnect(), nil)
+		s, err := bundle.NewShimClient(ctx, ns, ShimConnect(func() {
+			log.G(ctx).WithError(err).WithFields(logrus.Fields{
+				"id":        id,
+				"namespace": ns,
+			}).Error("connecting to shim")
+			err := r.cleanupAfterDeadShim(ctx, bundle, ns, id, pid)
+			if err != nil {
+				log.G(ctx).WithError(err).WithField("bundle", bundle.path).
+					Error("cleaning up after dead shim")
+			}
+		}), nil)
 		if err != nil {
 			log.G(ctx).WithError(err).WithFields(logrus.Fields{
 				"id":        id,
 				"namespace": ns,
 			}).Error("connecting to shim")
-			err := r.cleanupAfterDeadShim(ctx, bundle, ns, id, pid, nil)
+			err := r.cleanupAfterDeadShim(ctx, bundle, ns, id, pid)
 			if err != nil {
 				log.G(ctx).WithError(err).WithField("bundle", bundle.path).
 					Error("cleaning up after dead shim")
@@ -419,24 +421,13 @@ func (r *Runtime) loadTasks(ctx context.Context, ns string) ([]*Task, error) {
 	return o, nil
 }
 
-func (r *Runtime) cleanupAfterDeadShim(ctx context.Context, bundle *bundle, ns, id string, pid int, ec chan runc.Exit) error {
+func (r *Runtime) cleanupAfterDeadShim(ctx context.Context, bundle *bundle, ns, id string, pid int) error {
 	ctx = namespaces.WithNamespace(ctx, ns)
 	if err := r.terminate(ctx, bundle, ns, id); err != nil {
 		if r.config.ShimDebug {
 			return errors.Wrap(err, "failed to terminate task, leaving bundle for debugging")
 		}
 		log.G(ctx).WithError(err).Warn("failed to terminate task")
-	}
-
-	if ec != nil {
-		// if sub-reaper is set, reap our new child
-		if v, err := sys.GetSubreaper(); err == nil && v == 1 {
-			for e := range ec {
-				if e.Pid == pid {
-					break
-				}
-			}
-		}
 	}
 
 	// Notify Client
@@ -449,6 +440,7 @@ func (r *Runtime) cleanupAfterDeadShim(ctx context.Context, bundle *bundle, ns, 
 		ExitedAt:    exitedAt,
 	})
 
+	r.tasks.Delete(ctx, id)
 	if err := bundle.Delete(); err != nil {
 		log.G(ctx).WithError(err).Error("delete bundle")
 	}
@@ -464,12 +456,10 @@ func (r *Runtime) cleanupAfterDeadShim(ctx context.Context, bundle *bundle, ns, 
 }
 
 func (r *Runtime) terminate(ctx context.Context, bundle *bundle, ns, id string) error {
-	ctx = namespaces.WithNamespace(ctx, ns)
 	rt, err := r.getRuntime(ctx, ns, id)
 	if err != nil {
 		return err
 	}
-
 	if err := rt.Delete(ctx, id, &runc.DeleteOpts{
 		Force: true,
 	}); err != nil {

--- a/components/engine/vendor/github.com/containerd/containerd/linux/shim/service_linux.go
+++ b/components/engine/vendor/github.com/containerd/containerd/linux/shim/service_linux.go
@@ -33,7 +33,9 @@ func (p *linuxPlatform) CopyConsole(ctx context.Context, console console.Console
 		cwg.Add(1)
 		go func() {
 			cwg.Done()
-			io.Copy(epollConsole, in)
+			p := bufPool.Get().(*[]byte)
+			defer bufPool.Put(p)
+			io.CopyBuffer(epollConsole, in, *p)
 		}()
 	}
 
@@ -49,7 +51,9 @@ func (p *linuxPlatform) CopyConsole(ctx context.Context, console console.Console
 	cwg.Add(1)
 	go func() {
 		cwg.Done()
-		io.Copy(outw, epollConsole)
+		p := bufPool.Get().(*[]byte)
+		defer bufPool.Put(p)
+		io.CopyBuffer(outw, epollConsole, *p)
 		epollConsole.Close()
 		outr.Close()
 		outw.Close()

--- a/components/engine/vendor/github.com/containerd/containerd/linux/shim/service_unix.go
+++ b/components/engine/vendor/github.com/containerd/containerd/linux/shim/service_unix.go
@@ -24,7 +24,10 @@ func (p *unixPlatform) CopyConsole(ctx context.Context, console console.Console,
 		cwg.Add(1)
 		go func() {
 			cwg.Done()
-			io.Copy(console, in)
+			p := bufPool.Get().(*[]byte)
+			defer bufPool.Put(p)
+
+			io.CopyBuffer(console, in, *p)
 		}()
 	}
 	outw, err := fifo.OpenFifo(ctx, stdout, syscall.O_WRONLY, 0)
@@ -39,7 +42,10 @@ func (p *unixPlatform) CopyConsole(ctx context.Context, console console.Console,
 	cwg.Add(1)
 	go func() {
 		cwg.Done()
-		io.Copy(outw, console)
+		p := bufPool.Get().(*[]byte)
+		defer bufPool.Put(p)
+
+		io.CopyBuffer(outw, console, *p)
 		console.Close()
 		outr.Close()
 		outw.Close()

--- a/components/engine/vendor/github.com/containerd/containerd/linux/task.go
+++ b/components/engine/vendor/github.com/containerd/containerd/linux/task.go
@@ -6,9 +6,6 @@ import (
 	"context"
 	"sync"
 
-	"github.com/pkg/errors"
-	"google.golang.org/grpc"
-
 	"github.com/containerd/cgroups"
 	eventstypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/api/types/task"
@@ -20,6 +17,8 @@ import (
 	"github.com/containerd/containerd/runtime"
 	runc "github.com/containerd/go-runc"
 	"github.com/gogo/protobuf/types"
+	"github.com/pkg/errors"
+	"github.com/stevvooe/ttrpc"
 )
 
 // Task on a linux based system
@@ -109,7 +108,7 @@ func (t *Task) State(ctx context.Context) (runtime.State, error) {
 		ID: t.id,
 	})
 	if err != nil {
-		if err != grpc.ErrServerStopped {
+		if errors.Cause(err) != ttrpc.ErrClosed {
 			return runtime.State{}, errdefs.FromGRPC(err)
 		}
 		return runtime.State{}, errdefs.ErrNotFound

--- a/components/engine/vendor/github.com/containerd/containerd/metadata/buckets.go
+++ b/components/engine/vendor/github.com/containerd/containerd/metadata/buckets.go
@@ -106,13 +106,8 @@ func imagesBucketPath(namespace string) [][]byte {
 	return [][]byte{bucketKeyVersion, []byte(namespace), bucketKeyObjectImages}
 }
 
-func withImagesBucket(tx *bolt.Tx, namespace string, fn func(bkt *bolt.Bucket) error) error {
-	bkt, err := createBucketIfNotExists(tx, imagesBucketPath(namespace)...)
-	if err != nil {
-		return err
-	}
-
-	return fn(bkt)
+func createImagesBucket(tx *bolt.Tx, namespace string) (*bolt.Bucket, error) {
+	return createBucketIfNotExists(tx, imagesBucketPath(namespace)...)
 }
 
 func getImagesBucket(tx *bolt.Tx, namespace string) *bolt.Bucket {
@@ -141,6 +136,10 @@ func createSnapshotterBucket(tx *bolt.Tx, namespace, snapshotter string) (*bolt.
 		return nil, err
 	}
 	return bkt, nil
+}
+
+func getSnapshottersBucket(tx *bolt.Tx, namespace string) *bolt.Bucket {
+	return getBucket(tx, bucketKeyVersion, []byte(namespace), bucketKeyObjectSnapshots)
 }
 
 func getSnapshotterBucket(tx *bolt.Tx, namespace, snapshotter string) *bolt.Bucket {

--- a/components/engine/vendor/github.com/containerd/containerd/metadata/content.go
+++ b/components/engine/vendor/github.com/containerd/containerd/metadata/content.go
@@ -318,12 +318,23 @@ func (cs *contentStore) Writer(ctx context.Context, ref string, size int64, expe
 	cs.l.RLock()
 	defer cs.l.RUnlock()
 
-	var w content.Writer
+	var (
+		w      content.Writer
+		exists bool
+	)
 	if err := update(ctx, cs.db, func(tx *bolt.Tx) error {
 		if expected != "" {
 			cbkt := getBlobBucket(tx, ns, expected)
 			if cbkt != nil {
-				return errors.Wrapf(errdefs.ErrAlreadyExists, "content %v", expected)
+				// Add content to lease to prevent other reference removals
+				// from effecting this object during a provided lease
+				if err := addContentLease(ctx, tx, expected); err != nil {
+					return errors.Wrap(err, "unable to lease content")
+				}
+				// Return error outside of transaction to ensure
+				// commit succeeds with the lease.
+				exists = true
+				return nil
 			}
 		}
 
@@ -362,6 +373,9 @@ func (cs *contentStore) Writer(ctx context.Context, ref string, size int64, expe
 		return err
 	}); err != nil {
 		return nil, err
+	}
+	if exists {
+		return nil, errors.Wrapf(errdefs.ErrAlreadyExists, "content %v", expected)
 	}
 
 	// TODO: keep the expected in the writer to use on commit

--- a/components/engine/vendor/github.com/containerd/containerd/reaper/reaper.go
+++ b/components/engine/vendor/github.com/containerd/containerd/reaper/reaper.go
@@ -15,7 +15,7 @@ import (
 // ErrNoSuchProcess is returned when the process no longer exists
 var ErrNoSuchProcess = errors.New("no such process")
 
-const bufferSize = 1024
+const bufferSize = 32
 
 // Reap should be called when the process receives an SIGCHLD.  Reap will reap
 // all exited processes and close their wait channels

--- a/components/engine/vendor/github.com/containerd/containerd/rootfs/diff.go
+++ b/components/engine/vendor/github.com/containerd/containerd/rootfs/diff.go
@@ -39,7 +39,7 @@ func Diff(ctx context.Context, snapshotID string, sn snapshots.Snapshotter, d di
 		if err != nil {
 			return ocispec.Descriptor{}, err
 		}
-		defer sn.Remove(ctx, lowerKey)
+		defer sn.Remove(ctx, upperKey)
 	}
 
 	return d.DiffMounts(ctx, lower, upper, opts...)

--- a/components/engine/vendor/github.com/containerd/containerd/runtime/task_list.go
+++ b/components/engine/vendor/github.com/containerd/containerd/runtime/task_list.go
@@ -92,7 +92,7 @@ func (l *TaskList) AddWithNamespace(namespace string, t Task) error {
 }
 
 // Delete a task
-func (l *TaskList) Delete(ctx context.Context, t Task) {
+func (l *TaskList) Delete(ctx context.Context, id string) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	namespace, err := namespaces.NamespaceRequired(ctx)
@@ -101,6 +101,6 @@ func (l *TaskList) Delete(ctx context.Context, t Task) {
 	}
 	tasks, ok := l.tasks[namespace]
 	if ok {
-		delete(tasks, t.ID())
+		delete(tasks, id)
 	}
 }

--- a/components/engine/vendor/github.com/containerd/containerd/server/config.go
+++ b/components/engine/vendor/github.com/containerd/containerd/server/config.go
@@ -23,8 +23,6 @@ type Config struct {
 	Metrics MetricsConfig `toml:"metrics"`
 	// Plugins provides plugin specific configuration for the initialization of a plugin
 	Plugins map[string]toml.Primitive `toml:"plugins"`
-	// NoSubreaper disables containerd as a subreaper
-	NoSubreaper bool `toml:"no_subreaper"`
 	// OOMScore adjust the containerd's oom score
 	OOMScore int `toml:"oom_score"`
 	// Cgroup specifies cgroup information for the containerd daemon process

--- a/components/engine/vendor/github.com/containerd/containerd/server/server_linux.go
+++ b/components/engine/vendor/github.com/containerd/containerd/server/server_linux.go
@@ -12,16 +12,10 @@ import (
 
 // apply sets config settings on the server process
 func apply(ctx context.Context, config *Config) error {
-	if !config.NoSubreaper {
-		log.G(ctx).Info("setting subreaper...")
-		if err := sys.SetSubreaper(1); err != nil {
-			return err
-		}
-	}
 	if config.OOMScore != 0 {
-		log.G(ctx).Infof("changing OOM score to %d", config.OOMScore)
+		log.G(ctx).Debugf("changing OOM score to %d", config.OOMScore)
 		if err := sys.SetOOMScore(os.Getpid(), config.OOMScore); err != nil {
-			return err
+			log.G(ctx).WithError(err).Errorf("failed to change OOM score to %d", config.OOMScore)
 		}
 	}
 	if config.Cgroup.Path != "" {

--- a/components/engine/vendor/github.com/containerd/containerd/vendor.conf
+++ b/components/engine/vendor/github.com/containerd/containerd/vendor.conf
@@ -1,7 +1,7 @@
 github.com/coreos/go-systemd 48702e0da86bd25e76cfef347e2adeb434a0d0a6
-github.com/containerd/go-runc ed1cbe1fc31f5fb2359d3a54b6330d1a097858b7
+github.com/containerd/go-runc 4f6e87ae043f859a38255247b49c9abc262d002f
 github.com/containerd/console 84eeaae905fa414d03e07bcd6c8d3f19e7cf180e
-github.com/containerd/cgroups 29da22c6171a4316169f9205ab6c49f59b5b852f
+github.com/containerd/cgroups c0710c92e8b3a44681d1321dcfd1360fc5c6c089
 github.com/containerd/typeurl f6943554a7e7e88b3c14aad190bf05932da84788
 github.com/docker/go-metrics 8fd5772bf1584597834c6f7961a530f06cbfbb87
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
@@ -16,7 +16,7 @@ github.com/docker/go-units v0.3.1
 github.com/gogo/protobuf v0.5
 github.com/golang/protobuf 1643683e1b54a9e88ad26d98f81400c8c9d9f4f9
 github.com/opencontainers/runtime-spec v1.0.0
-github.com/opencontainers/runc 74a17296470088de3805e138d3d87c62e613dfc4
+github.com/opencontainers/runc 9f9c96235cc97674e935002fc3d78361b696a69e
 github.com/sirupsen/logrus v1.0.0
 github.com/containerd/btrfs cc52c4dea2ce11a44e6639e561bb5c2af9ada9e3
 github.com/stretchr/testify v1.1.4
@@ -32,13 +32,12 @@ golang.org/x/sys 314a259e304ff91bd6985da2a7149bbf91237993 https://github.com/gol
 github.com/opencontainers/image-spec v1.0.0
 github.com/containerd/continuity cf279e6ac893682272b4479d4c67fd3abf878b4e
 golang.org/x/sync 450f422ab23cf9881c94e2db30cac0eb1b7cf80c
-github.com/BurntSushi/toml v0.2.0-21-g9906417
+github.com/BurntSushi/toml a368813c5e648fee92e5f6c30e3944ff9d5e8895
 github.com/grpc-ecosystem/go-grpc-prometheus 6b7015e65d366bf3f19b2b2a000a831940f0f7e0
 github.com/Microsoft/go-winio v0.4.4
 github.com/Microsoft/hcsshim v0.6.7
-github.com/Microsoft/opengcs v0.3.2
 github.com/boltdb/bolt e9cf4fae01b5a8ff89d0ec6b32f0d9c9f79aefdd
 google.golang.org/genproto d80a6e20e776b0b17a324d0ba1ab50a39c8e8944
 golang.org/x/text 19e51611da83d6be54ddafce4a4af510cb3e9ea4
 github.com/dmcgowan/go-tar go1.10
-github.com/stevvooe/ttrpc 76e68349ad9ab4d03d764c713826d31216715e4f
+github.com/stevvooe/ttrpc d4528379866b0ce7e9d71f3eb96f0582fc374577

--- a/components/engine/vendor/github.com/containerd/go-runc/utils.go
+++ b/components/engine/vendor/github.com/containerd/go-runc/utils.go
@@ -1,8 +1,10 @@
 package runc
 
 import (
+	"bytes"
 	"io/ioutil"
 	"strconv"
+	"sync"
 	"syscall"
 )
 
@@ -25,4 +27,19 @@ func exitStatus(status syscall.WaitStatus) int {
 		return exitSignalOffset + int(status.Signal())
 	}
 	return status.ExitStatus()
+}
+
+var bytesBufferPool = sync.Pool{
+	New: func() interface{} {
+		return bytes.NewBuffer(nil)
+	},
+}
+
+func getBuf() *bytes.Buffer {
+	return bytesBufferPool.Get().(*bytes.Buffer)
+}
+
+func putBuf(b *bytes.Buffer) {
+	b.Reset()
+	bytesBufferPool.Put(b)
 }

--- a/components/engine/vendor/github.com/stevvooe/ttrpc/channel.go
+++ b/components/engine/vendor/github.com/stevvooe/ttrpc/channel.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/binary"
 	"io"
+	"net"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -60,16 +61,18 @@ func writeMessageHeader(w io.Writer, p []byte, mh messageHeader) error {
 var buffers sync.Pool
 
 type channel struct {
+	conn  net.Conn
 	bw    *bufio.Writer
 	br    *bufio.Reader
 	hrbuf [messageHeaderLength]byte // avoid alloc when reading header
 	hwbuf [messageHeaderLength]byte
 }
 
-func newChannel(w io.Writer, r io.Reader) *channel {
+func newChannel(conn net.Conn) *channel {
 	return &channel{
-		bw: bufio.NewWriter(w),
-		br: bufio.NewReader(r),
+		conn: conn,
+		bw:   bufio.NewWriter(conn),
+		br:   bufio.NewReader(conn),
 	}
 }
 

--- a/components/engine/vendor/github.com/stevvooe/ttrpc/server.go
+++ b/components/engine/vendor/github.com/stevvooe/ttrpc/server.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	ErrServerClosed = errors.New("ttrpc: server close")
+	ErrServerClosed = errors.New("ttrpc: server closed")
 )
 
 type Server struct {
@@ -281,7 +281,7 @@ func (c *serverConn) run(sctx context.Context) {
 	)
 
 	var (
-		ch          = newChannel(c.conn, c.conn)
+		ch          = newChannel(c.conn)
 		ctx, cancel = context.WithCancel(sctx)
 		active      int
 		state       connState = connStateIdle


### PR DESCRIPTION
Backport containerd 1.0.2 bump - https://github.com/moby/moby/pull/36308
```
git cherry-pick -s -x -Xsubtree=components/engine c2fb6db55be08da95b15bee730a191094f846577
```

Also bumps vendors to match contained 1.0.2 vendors... these don't match moby/moby since moby/moby is not tracking 1.0.2 for vendored deps.