### PR TITLE
[17.12] Add /proc/keys to masked paths

### DIFF
--- a/components/engine/oci/defaults.go
+++ b/components/engine/oci/defaults.go
@@ -115,6 +115,7 @@ func DefaultLinuxSpec() specs.Spec {
 	s.Linux = &specs.Linux{
 		MaskedPaths: []string{
 			"/proc/kcore",
+			"/proc/keys",
 			"/proc/latency_stats",
 			"/proc/timer_list",
 			"/proc/timer_stats",


### PR DESCRIPTION
backport of:
* https://github.com/moby/moby/pull/36368 Add /proc/keys to masked paths

with cherry-pick of git commit https://github.com/moby/moby/pull/36368/commits/de23cb9:
```
$ git cherry-pick -s -x -Xsubtree=components/engine de23cb9
```

no conflicts.