### PR TITLE
[18.03] Add --template-driver option for secrets/configs

### DIFF
--- a/components/cli/cli/command/config/create.go
+++ b/components/cli/cli/command/config/create.go
@@ -16,9 +16,10 @@ import (
 )
 
 type createOptions struct {
-	name   string
-	file   string
-	labels opts.ListOpts
+	name           string
+	templateDriver string
+	file           string
+	labels         opts.ListOpts
 }
 
 func newConfigCreateCommand(dockerCli command.Cli) *cobra.Command {
@@ -38,6 +39,8 @@ func newConfigCreateCommand(dockerCli command.Cli) *cobra.Command {
 	}
 	flags := cmd.Flags()
 	flags.VarP(&createOpts.labels, "label", "l", "Config labels")
+	flags.StringVar(&createOpts.templateDriver, "template-driver", "", "Template driver")
+	flags.SetAnnotation("driver", "version", []string{"1.37"})
 
 	return cmd
 }
@@ -68,7 +71,11 @@ func runConfigCreate(dockerCli command.Cli, options createOptions) error {
 		},
 		Data: configData,
 	}
-
+	if options.templateDriver != "" {
+		spec.Templating = &swarm.Driver{
+			Name: options.templateDriver,
+		}
+	}
 	r, err := client.ConfigCreate(ctx, spec)
 	if err != nil {
 		return err

--- a/components/cli/cli/command/secret/create.go
+++ b/components/cli/cli/command/secret/create.go
@@ -16,10 +16,11 @@ import (
 )
 
 type createOptions struct {
-	name   string
-	driver string
-	file   string
-	labels opts.ListOpts
+	name           string
+	driver         string
+	templateDriver string
+	file           string
+	labels         opts.ListOpts
 }
 
 func newSecretCreateCommand(dockerCli command.Cli) *cobra.Command {
@@ -43,6 +44,8 @@ func newSecretCreateCommand(dockerCli command.Cli) *cobra.Command {
 	flags.VarP(&options.labels, "label", "l", "Secret labels")
 	flags.StringVarP(&options.driver, "driver", "d", "", "Secret driver")
 	flags.SetAnnotation("driver", "version", []string{"1.31"})
+	flags.StringVar(&options.templateDriver, "template-driver", "", "Template driver")
+	flags.SetAnnotation("driver", "version", []string{"1.37"})
 
 	return cmd
 }
@@ -71,7 +74,11 @@ func runSecretCreate(dockerCli command.Cli, options createOptions) error {
 			Name: options.driver,
 		}
 	}
-
+	if options.templateDriver != "" {
+		spec.Templating = &swarm.Driver{
+			Name: options.templateDriver,
+		}
+	}
 	r, err := client.SecretCreate(ctx, spec)
 	if err != nil {
 		return err

--- a/components/cli/cli/command/secret/create_test.go
+++ b/components/cli/cli/command/secret/create_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/docker/cli/internal/test/testutil"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/gotestyourself/gotestyourself/golden"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
@@ -52,15 +51,22 @@ func TestSecretCreateErrors(t *testing.T) {
 
 func TestSecretCreateWithName(t *testing.T) {
 	name := "foo"
-	var actual []byte
+	data, err := ioutil.ReadFile(filepath.Join("testdata", secretDataFile))
+	assert.NoError(t, err)
+
+	expected := swarm.SecretSpec{
+		Annotations: swarm.Annotations{
+			Name:   name,
+			Labels: make(map[string]string),
+		},
+		Data: data,
+	}
+
 	cli := test.NewFakeCli(&fakeClient{
 		secretCreateFunc: func(spec swarm.SecretSpec) (types.SecretCreateResponse, error) {
-			if spec.Name != name {
-				return types.SecretCreateResponse{}, errors.Errorf("expected name %q, got %q", name, spec.Name)
+			if !reflect.DeepEqual(spec, expected) {
+				return types.SecretCreateResponse{}, errors.Errorf("expected %+v, got %+v", expected, spec)
 			}
-
-			actual = spec.Data
-
 			return types.SecretCreateResponse{
 				ID: "ID-" + spec.Name,
 			}, nil
@@ -70,7 +76,6 @@ func TestSecretCreateWithName(t *testing.T) {
 	cmd := newSecretCreateCommand(cli)
 	cmd.SetArgs([]string{name, filepath.Join("testdata", secretDataFile)})
 	assert.NoError(t, cmd.Execute())
-	golden.Assert(t, string(actual), secretDataFile)
 	assert.Equal(t, "ID-"+name, strings.TrimSpace(cli.OutBuffer().String()))
 }
 
@@ -86,7 +91,7 @@ func TestSecretCreateWithDriver(t *testing.T) {
 				return types.SecretCreateResponse{}, errors.Errorf("expected name %q, got %q", name, spec.Name)
 			}
 
-			if !reflect.DeepEqual(spec.Driver.Name, expectedDriver.Name) {
+			if spec.Driver.Name != expectedDriver.Name {
 				return types.SecretCreateResponse{}, errors.Errorf("expected driver %v, got %v", expectedDriver, spec.Labels)
 			}
 
@@ -99,6 +104,35 @@ func TestSecretCreateWithDriver(t *testing.T) {
 	cmd := newSecretCreateCommand(cli)
 	cmd.SetArgs([]string{name})
 	cmd.Flags().Set("driver", expectedDriver.Name)
+	assert.NoError(t, cmd.Execute())
+	assert.Equal(t, "ID-"+name, strings.TrimSpace(cli.OutBuffer().String()))
+}
+
+func TestSecretCreateWithTemplatingDriver(t *testing.T) {
+	expectedDriver := &swarm.Driver{
+		Name: "template-driver",
+	}
+	name := "foo"
+
+	cli := test.NewFakeCli(&fakeClient{
+		secretCreateFunc: func(spec swarm.SecretSpec) (types.SecretCreateResponse, error) {
+			if spec.Name != name {
+				return types.SecretCreateResponse{}, errors.Errorf("expected name %q, got %q", name, spec.Name)
+			}
+
+			if spec.Templating.Name != expectedDriver.Name {
+				return types.SecretCreateResponse{}, errors.Errorf("expected driver %v, got %v", expectedDriver, spec.Labels)
+			}
+
+			return types.SecretCreateResponse{
+				ID: "ID-" + spec.Name,
+			}, nil
+		},
+	})
+
+	cmd := newSecretCreateCommand(cli)
+	cmd.SetArgs([]string{name})
+	cmd.Flags().Set("template-driver", expectedDriver.Name)
 	assert.NoError(t, cmd.Execute())
 	assert.Equal(t, "ID-"+name, strings.TrimSpace(cli.OutBuffer().String()))
 }

--- a/components/cli/docs/reference/commandline/secret_create.md
+++ b/components/cli/docs/reference/commandline/secret_create.md
@@ -16,13 +16,13 @@ keywords: ["secret, create"]
 # secret create
 
 ```Markdown
-Usage:	docker secret create [OPTIONS] SECRET file|-
+Usage:	docker secret create [OPTIONS] SECRET [file|-]
 
 Create a secret from a file or STDIN as content
 
 Options:
-      --help          Print usage
-  -l, --label list    Secret labels (default [])
+  -l, --label list               Secret labels
+      --template-driver string   Template driver
 ```
 
 ## Description


### PR DESCRIPTION
cherry-pick of https://github.com/docker/cli/pull/896/commits/d11b5ccdfa4df102c1783afca28de25323e6f520 (https://github.com/docker/cli/pull/896) for 18.03

```
git checkout -b 18.03-backport-templated-configs-secrets upstream/18.03
git cherry-pick -s -S -x -Xsubtree=components/cli d11b5ccdfa4df102c1783afca28de25323e6f520
git push --set-upstream origin 18.03-backport-templated-configs-secrets
```

no conflicts