### PR TITLE
[18.03] Fixes tests to have the ci green

### DIFF
--- a/components/cli/cli/command/container/client_test.go
+++ b/components/cli/cli/command/container/client_test.go
@@ -16,6 +16,7 @@ type fakeClient struct {
 	execInspectFunc       func(execID string) (types.ContainerExecInspect, error)
 	execCreateFunc        func(container string, config types.ExecConfig) (types.IDResponse, error)
 	createContainerFunc   func(config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, containerName string) (container.ContainerCreateCreatedBody, error)
+	containerStartFunc    func(container string, options types.ContainerStartOptions) error
 	imageCreateFunc       func(parentReference string, options types.ImageCreateOptions) (io.ReadCloser, error)
 	infoFunc              func() (types.Info, error)
 	containerStatPathFunc func(container, path string) (types.ContainerPathStat, error)
@@ -115,4 +116,11 @@ func (f *fakeClient) ContainerWait(_ context.Context, container string, _ contai
 		return f.waitFunc(container)
 	}
 	return nil, nil
+}
+
+func (f *fakeClient) ContainerStart(_ context.Context, container string, options types.ContainerStartOptions) error {
+	if f.containerStartFunc != nil {
+		return f.containerStartFunc(container, options)
+	}
+	return nil
 }

--- a/components/cli/cli/command/container/opts.go
+++ b/components/cli/cli/command/container/opts.go
@@ -145,7 +145,7 @@ func addFlags(flags *pflag.FlagSet) *containerOptions {
 		expose:            opts.NewListOpts(nil),
 		extraHosts:        opts.NewListOpts(opts.ValidateExtraHost),
 		groupAdd:          opts.NewListOpts(nil),
-		labels:            opts.NewListOpts(opts.ValidateLabel),
+		labels:            opts.NewListOpts(nil),
 		labelsFile:        opts.NewListOpts(nil),
 		linkLocalIPs:      opts.NewListOpts(nil),
 		links:             opts.NewListOpts(opts.ValidateLink),

--- a/components/cli/cli/command/container/run_test.go
+++ b/components/cli/cli/command/container/run_test.go
@@ -1,0 +1,25 @@
+package container
+
+import (
+	"testing"
+
+	"github.com/docker/cli/internal/test"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunLabel(t *testing.T) {
+	cli := test.NewFakeCli(&fakeClient{
+		createContainerFunc: func(_ *container.Config, _ *container.HostConfig, _ *network.NetworkingConfig, _ string) (container.ContainerCreateCreatedBody, error) {
+			return container.ContainerCreateCreatedBody{
+				ID: "id",
+			}, nil
+		},
+		Version: "1.36",
+	})
+	cmd := NewRunCommand(cli)
+	cmd.Flags().Set("detach", "true")
+	cmd.SetArgs([]string{"--label", "foo", "busybox"})
+	assert.NoError(t, cmd.Execute())
+}

--- a/components/engine/integration-cli/docker_cli_cp_from_container_test.go
+++ b/components/engine/integration-cli/docker_cli_cp_from_container_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/go-check/check"
 )
 
-// docker cp CONTAINER:PATH LOCALPATH
-
 // Try all of the test cases from the archive package which implements the
 // internals of `docker cp` and ensure that the behavior matches when actually
 // copying to and from containers.
@@ -20,67 +18,9 @@ import (
 // 3. DST parent directory must exist.
 // 4. If DST exists as a file, it must not end with a trailing separator.
 
-// First get these easy error cases out of the way.
-
-// Test for error when SRC does not exist.
-func (s *DockerSuite) TestCpFromErrSrcNotExists(c *check.C) {
-	containerID := makeTestContainer(c, testContainerOptions{})
-
-	tmpDir := getTestDir(c, "test-cp-from-err-src-not-exists")
-	defer os.RemoveAll(tmpDir)
-
-	err := runDockerCp(c, containerCpPath(containerID, "file1"), tmpDir, nil)
-	c.Assert(err, checker.NotNil)
-
-	c.Assert(isCpNotExist(err), checker.True, check.Commentf("expected IsNotExist error, but got %T: %s", err, err))
-}
-
-// Test for error when SRC ends in a trailing
-// path separator but it exists as a file.
-func (s *DockerSuite) TestCpFromErrSrcNotDir(c *check.C) {
-	testRequires(c, DaemonIsLinux)
-	containerID := makeTestContainer(c, testContainerOptions{addContent: true})
-
-	tmpDir := getTestDir(c, "test-cp-from-err-src-not-dir")
-	defer os.RemoveAll(tmpDir)
-
-	err := runDockerCp(c, containerCpPathTrailingSep(containerID, "file1"), tmpDir, nil)
-	c.Assert(err, checker.NotNil)
-
-	c.Assert(isCpNotDir(err), checker.True, check.Commentf("expected IsNotDir error, but got %T: %s", err, err))
-}
-
-// Test for error when DST ends in a trailing
-// path separator but exists as a file.
-func (s *DockerSuite) TestCpFromErrDstNotDir(c *check.C) {
-	testRequires(c, DaemonIsLinux)
-	containerID := makeTestContainer(c, testContainerOptions{addContent: true})
-
-	tmpDir := getTestDir(c, "test-cp-from-err-dst-not-dir")
-	defer os.RemoveAll(tmpDir)
-
-	makeTestContentInDir(c, tmpDir)
-
-	// Try with a file source.
-	srcPath := containerCpPath(containerID, "/file1")
-	dstPath := cpPathTrailingSep(tmpDir, "file1")
-
-	err := runDockerCp(c, srcPath, dstPath, nil)
-	c.Assert(err, checker.NotNil)
-
-	c.Assert(isCpNotDir(err), checker.True, check.Commentf("expected IsNotDir error, but got %T: %s", err, err))
-
-	// Try with a directory source.
-	srcPath = containerCpPath(containerID, "/dir1")
-
-	err = runDockerCp(c, srcPath, dstPath, nil)
-	c.Assert(err, checker.NotNil)
-
-	c.Assert(isCpNotDir(err), checker.True, check.Commentf("expected IsNotDir error, but got %T: %s", err, err))
-}
-
 // Check that copying from a container to a local symlink copies to the symlink
 // target and does not overwrite the local symlink itself.
+// TODO: move to docker/cli and/or integration/container/copy_test.go
 func (s *DockerSuite) TestCpFromSymlinkDestination(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	containerID := makeTestContainer(c, testContainerOptions{addContent: true})

--- a/components/engine/integration-cli/docker_cli_cp_to_container_test.go
+++ b/components/engine/integration-cli/docker_cli_cp_to_container_test.go
@@ -2,14 +2,10 @@ package main
 
 import (
 	"os"
-	"runtime"
-	"strings"
 
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/go-check/check"
 )
-
-// docker cp LOCALPATH CONTAINER:PATH
 
 // Try all of the test cases from the archive package which implements the
 // internals of `docker cp` and ensure that the behavior matches when actually
@@ -20,124 +16,6 @@ import (
 // 2. If SRC ends with a trailing separator, it must be a directory.
 // 3. DST parent directory must exist.
 // 4. If DST exists as a file, it must not end with a trailing separator.
-
-// First get these easy error cases out of the way.
-
-// Test for error when SRC does not exist.
-func (s *DockerSuite) TestCpToErrSrcNotExists(c *check.C) {
-	containerID := makeTestContainer(c, testContainerOptions{})
-
-	tmpDir := getTestDir(c, "test-cp-to-err-src-not-exists")
-	defer os.RemoveAll(tmpDir)
-
-	srcPath := cpPath(tmpDir, "file1")
-	dstPath := containerCpPath(containerID, "file1")
-	_, srcStatErr := os.Stat(srcPath)
-	c.Assert(os.IsNotExist(srcStatErr), checker.True)
-
-	err := runDockerCp(c, srcPath, dstPath, nil)
-	if runtime.GOOS == "windows" {
-		// Go 1.9+ on Windows returns a different error for `os.Stat()`, see
-		// https://github.com/golang/go/commit/6144c7270e5812d9de8fb97456ee4e5ae657fcbb#diff-f63e1a4b4377b2fe0b05011db3df9599
-		//
-		// Go 1.8: CreateFile C:\not-exist: The system cannot find the file specified.
-		// Go 1.9: GetFileAttributesEx C:\not-exist: The system cannot find the file specified.
-		//
-		// Due to the CLI using a different version than the daemon, comparing the
-		// error message won't work, so just hard-code the common part here.
-		//
-		// TODO this should probably be a test in the CLI repository instead
-		c.Assert(strings.ToLower(err.Error()), checker.Contains, "cannot find the file specified")
-		c.Assert(strings.ToLower(err.Error()), checker.Contains, strings.ToLower(tmpDir))
-	} else {
-		c.Assert(strings.ToLower(err.Error()), checker.Contains, strings.ToLower(srcStatErr.Error()))
-	}
-}
-
-// Test for error when SRC ends in a trailing
-// path separator but it exists as a file.
-func (s *DockerSuite) TestCpToErrSrcNotDir(c *check.C) {
-	containerID := makeTestContainer(c, testContainerOptions{})
-
-	tmpDir := getTestDir(c, "test-cp-to-err-src-not-dir")
-	defer os.RemoveAll(tmpDir)
-
-	makeTestContentInDir(c, tmpDir)
-
-	srcPath := cpPathTrailingSep(tmpDir, "file1")
-	dstPath := containerCpPath(containerID, "testDir")
-
-	err := runDockerCp(c, srcPath, dstPath, nil)
-	c.Assert(err, checker.NotNil)
-
-	c.Assert(isCpNotDir(err), checker.True, check.Commentf("expected IsNotDir error, but got %T: %s", err, err))
-}
-
-// Test for error when SRC is a valid file or directory,
-// but the DST parent directory does not exist.
-func (s *DockerSuite) TestCpToErrDstParentNotExists(c *check.C) {
-	testRequires(c, DaemonIsLinux)
-	containerID := makeTestContainer(c, testContainerOptions{addContent: true})
-
-	tmpDir := getTestDir(c, "test-cp-to-err-dst-parent-not-exists")
-	defer os.RemoveAll(tmpDir)
-
-	makeTestContentInDir(c, tmpDir)
-
-	// Try with a file source.
-	srcPath := cpPath(tmpDir, "file1")
-	dstPath := containerCpPath(containerID, "/notExists", "file1")
-
-	err := runDockerCp(c, srcPath, dstPath, nil)
-	c.Assert(err, checker.NotNil)
-
-	c.Assert(isCpNotExist(err), checker.True, check.Commentf("expected IsNotExist error, but got %T: %s", err, err))
-
-	// Try with a directory source.
-	srcPath = cpPath(tmpDir, "dir1")
-
-	err = runDockerCp(c, srcPath, dstPath, nil)
-	c.Assert(err, checker.NotNil)
-
-	c.Assert(isCpNotExist(err), checker.True, check.Commentf("expected IsNotExist error, but got %T: %s", err, err))
-}
-
-// Test for error when DST ends in a trailing path separator but exists as a
-// file. Also test that we cannot overwrite an existing directory with a
-// non-directory and cannot overwrite an existing
-func (s *DockerSuite) TestCpToErrDstNotDir(c *check.C) {
-	testRequires(c, DaemonIsLinux)
-	containerID := makeTestContainer(c, testContainerOptions{addContent: true})
-
-	tmpDir := getTestDir(c, "test-cp-to-err-dst-not-dir")
-	defer os.RemoveAll(tmpDir)
-
-	makeTestContentInDir(c, tmpDir)
-
-	// Try with a file source.
-	srcPath := cpPath(tmpDir, "dir1/file1-1")
-	dstPath := containerCpPathTrailingSep(containerID, "file1")
-
-	// The client should encounter an error trying to stat the destination
-	// and then be unable to copy since the destination is asserted to be a
-	// directory but does not exist.
-	err := runDockerCp(c, srcPath, dstPath, nil)
-	c.Assert(err, checker.NotNil)
-
-	c.Assert(isCpDirNotExist(err), checker.True, check.Commentf("expected DirNotExist error, but got %T: %s", err, err))
-
-	// Try with a directory source.
-	srcPath = cpPath(tmpDir, "dir1")
-
-	// The client should encounter an error trying to stat the destination and
-	// then decide to extract to the parent directory instead with a rebased
-	// name in the source archive, but this directory would overwrite the
-	// existing file with the same name.
-	err = runDockerCp(c, srcPath, dstPath, nil)
-	c.Assert(err, checker.NotNil)
-
-	c.Assert(isCannotOverwriteNonDirWithDir(err), checker.True, check.Commentf("expected CannotOverwriteNonDirWithDir error, but got %T: %s", err, err))
-}
 
 // Check that copying from a local path to a symlink in a container copies to
 // the symlink target and does not overwrite the container symlink itself.

--- a/components/engine/integration-cli/docker_cli_cp_utils_test.go
+++ b/components/engine/integration-cli/docker_cli_cp_utils_test.go
@@ -228,16 +228,8 @@ func getTestDir(c *check.C, label string) (tmpDir string) {
 	return
 }
 
-func isCpNotExist(err error) bool {
-	return strings.Contains(strings.ToLower(err.Error()), "could not find the file")
-}
-
 func isCpDirNotExist(err error) bool {
 	return strings.Contains(err.Error(), archive.ErrDirNotExists.Error())
-}
-
-func isCpNotDir(err error) bool {
-	return strings.Contains(err.Error(), archive.ErrNotDirectory.Error()) || strings.Contains(err.Error(), "filename, directory name, or volume label syntax is incorrect")
 }
 
 func isCpCannotCopyDir(err error) bool {
@@ -246,10 +238,6 @@ func isCpCannotCopyDir(err error) bool {
 
 func isCpCannotCopyReadOnly(err error) bool {
 	return strings.Contains(err.Error(), "marked read-only")
-}
-
-func isCannotOverwriteNonDirWithDir(err error) bool {
-	return strings.Contains(err.Error(), "cannot overwrite non-directory")
 }
 
 func fileContentEquals(c *check.C, filename, contents string) (err error) {

--- a/components/engine/integration/container/copy_test.go
+++ b/components/engine/integration/container/copy_test.go
@@ -1,0 +1,65 @@
+package container // import "github.com/docker/docker/integration/container"
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
+	"github.com/docker/docker/integration/internal/container"
+	"github.com/docker/docker/internal/testutil"
+	"github.com/gotestyourself/gotestyourself/skip"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopyFromContainerPathDoesNotExist(t *testing.T) {
+	defer setupTest(t)()
+
+	ctx := context.Background()
+	apiclient := testEnv.APIClient()
+	cid := container.Create(t, ctx, apiclient)
+
+	_, _, err := apiclient.CopyFromContainer(ctx, cid, "/dne")
+	require.True(t, client.IsErrNotFound(err))
+	expected := fmt.Sprintf("No such container:path: %s:%s", cid, "/dne")
+	testutil.ErrorContains(t, err, expected)
+}
+
+func TestCopyFromContainerPathIsNotDir(t *testing.T) {
+	defer setupTest(t)()
+	skip.If(t, testEnv.OSType == "windows")
+
+	ctx := context.Background()
+	apiclient := testEnv.APIClient()
+	cid := container.Create(t, ctx, apiclient)
+
+	_, _, err := apiclient.CopyFromContainer(ctx, cid, "/etc/passwd/")
+	require.Contains(t, err.Error(), "not a directory")
+}
+
+func TestCopyToContainerPathDoesNotExist(t *testing.T) {
+	defer setupTest(t)()
+	skip.If(t, testEnv.OSType == "windows")
+
+	ctx := context.Background()
+	apiclient := testEnv.APIClient()
+	cid := container.Create(t, ctx, apiclient)
+
+	err := apiclient.CopyToContainer(ctx, cid, "/dne", nil, types.CopyToContainerOptions{})
+	require.True(t, client.IsErrNotFound(err))
+	expected := fmt.Sprintf("No such container:path: %s:%s", cid, "/dne")
+	testutil.ErrorContains(t, err, expected)
+}
+
+func TestCopyToContainerPathIsNotDir(t *testing.T) {
+	defer setupTest(t)()
+	skip.If(t, testEnv.OSType == "windows")
+
+	ctx := context.Background()
+	apiclient := testEnv.APIClient()
+	cid := container.Create(t, ctx, apiclient)
+
+	err := apiclient.CopyToContainer(ctx, cid, "/etc/passwd/", nil, types.CopyToContainerOptions{})
+	require.Contains(t, err.Error(), "not a directory")
+}


### PR DESCRIPTION
Fixes some failing tests on engine; more commits can be added to this, but we can merge at any point.

backport of:

* moby/moby#36427 Clean some docker_cli_build_tests that are cli-only
* https://github.com/docker/cli/pull/907 Add more container cp tests
* https://github.com/moby/moby/pull/36434 Migrate some container copy tests to integration

Also cherry-pick #446 👼 