### PR TITLE
[18.03] disallow attaching ingress network

### DIFF
--- a/components/cli/vendor.conf
+++ b/components/cli/vendor.conf
@@ -13,7 +13,7 @@ github.com/docker/go d30aec9fd63c35133f8f79c3412ad91a3b08be06
 github.com/docker/go-connections 7beb39f0b969b075d1325fecb092faf27fd357b6
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/docker/go-units 9e638d38cf6977a37a8ea0078f3ee75a7cdb2dd1
-github.com/docker/swarmkit 49a9d7f6ba3c1925262641e694c18eb43575f74b
+github.com/docker/swarmkit 11d7b06f48bc1d73fc6d8776c3552a4b11c94301
 github.com/emicklei/go-restful ff4f55a206334ef123e4f79bbf348980da81ca46
 github.com/emicklei/go-restful-swagger12 dcef7f55730566d41eae5db10e7d6981829720f6
 github.com/flynn-archive/go-shlex 3f9db97f856818214da2e1057f8ad84803971cff

--- a/components/engine/vendor.conf
+++ b/components/engine/vendor.conf
@@ -120,7 +120,7 @@ github.com/dmcgowan/go-tar go1.10
 github.com/stevvooe/ttrpc d4528379866b0ce7e9d71f3eb96f0582fc374577
 
 # cluster
-github.com/docker/swarmkit 49a9d7f6ba3c1925262641e694c18eb43575f74b
+github.com/docker/swarmkit 11d7b06f48bc1d73fc6d8776c3552a4b11c94301
 github.com/gogo/protobuf v0.4
 github.com/cloudflare/cfssl 7fb22c8cba7ecaf98e4082d22d65800cf45e042a
 github.com/google/certificate-transparency d90e65c3a07988180c5b1ece71791c0b6506826e

--- a/components/engine/vendor/github.com/docker/swarmkit/manager/controlapi/service.go
+++ b/components/engine/vendor/github.com/docker/swarmkit/manager/controlapi/service.go
@@ -644,7 +644,7 @@ func (s *Server) CreateService(ctx context.Context, request *api.CreateServiceRe
 		return nil, err
 	}
 
-	if err := s.validateNetworks(request.Spec.Networks); err != nil {
+	if err := s.validateNetworks(request.Spec.Task.Networks); err != nil {
 		return nil, err
 	}
 
@@ -724,6 +724,10 @@ func (s *Server) UpdateService(ctx context.Context, request *api.UpdateServiceRe
 		return nil, status.Errorf(codes.InvalidArgument, errInvalidArgument.Error())
 	}
 	if err := validateServiceSpec(request.Spec); err != nil {
+		return nil, err
+	}
+
+	if err := s.validateNetworks(request.Spec.Task.Networks); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This PR brings in https://github.com/docker/swarmkit/pull/2523; https://github.com/docker/swarmkit/compare/49a9d7f6ba3c1925262641e694c18eb43575f74b...11d7b06f48bc1d73fc6d8776c3552a4b11c94301

CLI vendoring is also updated, but did not bring in changes
