### PR TITLE
[18.03] Fixes binary installation

### DIFF
--- a/components/packaging/deb/build-deb
+++ b/components/packaging/deb/build-deb
@@ -7,15 +7,15 @@ if [[ -z "$DEB_VERSION" ]]; then
     exit 1
 fi
 
-# I want to rip this install-binaries script out so badly
-cd engine
-TMP_GOPATH="/go" bash hack/dockerfile/install-binaries.sh runc-dynamic containerd-dynamic proxy-dynamic tini
-if [[ $? -ne 0 ]]; then
-    echo "Binaries required for package building not installed correctly."
-    echo "Exiting..."
-    exit 1
-fi
-cd -
+(
+    set -e
+    cd engine
+    # I want to rip this install-binaries script out so badly
+    for component in tini proxy runc containerd;do
+        TMP_GOPATH="/go" hack/dockerfile/install/install.sh $component
+    done
+)
+
 echo VERSION AAA $VERSION
 
 VERSION=${VERSION:-$( cat engine/VERSION )}

--- a/components/packaging/rpm/centos-7/docker-ce.spec
+++ b/components/packaging/rpm/centos-7/docker-ce.spec
@@ -67,7 +67,9 @@ pushd /go/src/github.com/docker/cli
 make VERSION=%{_origversion} GITCOMMIT=%{_gitcommit} dynbinary manpages # cli
 popd
 pushd engine
-TMP_GOPATH="/go" hack/dockerfile/install-binaries.sh runc-dynamic containerd-dynamic proxy-dynamic tini
+for component in tini proxy runc containerd;do
+    TMP_GOPATH="/go" hack/dockerfile/install/install.sh $component
+done
 VERSION=%{_origversion} hack/make.sh dynbinary
 popd
 

--- a/components/packaging/rpm/fedora-26/docker-ce.spec
+++ b/components/packaging/rpm/fedora-26/docker-ce.spec
@@ -65,7 +65,9 @@ pushd /go/src/github.com/docker/cli
 make VERSION=%{_origversion} GITCOMMIT=%{_gitcommit} dynbinary manpages # cli
 popd
 pushd engine
-TMP_GOPATH="/go" hack/dockerfile/install-binaries.sh runc-dynamic containerd-dynamic proxy-dynamic tini
+for component in tini proxy runc containerd;do
+    TMP_GOPATH="/go" hack/dockerfile/install/install.sh $component
+done
 VERSION=%{_origversion} hack/make.sh dynbinary
 popd
 mkdir -p plugin

--- a/components/packaging/rpm/fedora-27/docker-ce.spec
+++ b/components/packaging/rpm/fedora-27/docker-ce.spec
@@ -66,7 +66,9 @@ pushd /go/src/github.com/docker/cli
 make VERSION=%{_origversion} GITCOMMIT=%{_gitcommit} dynbinary manpages # cli
 popd
 pushd engine
-TMP_GOPATH="/go" hack/dockerfile/install-binaries.sh runc-dynamic containerd-dynamic proxy-dynamic tini
+for component in tini proxy runc containerd;do
+    TMP_GOPATH="/go" hack/dockerfile/install/install.sh $component
+done
 VERSION=%{_origversion} hack/make.sh dynbinary
 popd
 mkdir -p plugin


### PR DESCRIPTION
```
git cherry-pick -x -s -Xsubtree="components/packaging" 59164bedeab571029805a107e8e5a32fc9cd56b3
```

Cherry pick of https://github.com/docker/docker-ce-packaging/pull/88

Cherry pick was __clean__

# Original text:

Binary installation was broken after the
hack/dockerfile/install-binaries script was removed.

This remedies that.

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>
(cherry picked from commit 59164bedeab571029805a107e8e5a32fc9cd56b3)
Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>