### PR TITLE
[18.03] fix static builds

### DIFF
--- a/components/engine/hack/dockerfile/install/containerd.installer
+++ b/components/engine/hack/dockerfile/install/containerd.installer
@@ -14,10 +14,15 @@ install_containerd() {
 
 	(
 
-		if [ "$1" == "static" ]; then
-			export BUILDTAGS='static_build netgo'
-			export EXTRA_FLAGS='-buildmod pie'
-			export EXTRA_LDFLAGS='-extldflags "-fno-PIC -static"'
+		export BUILDTAGS='static_build netgo'
+		export EXTRA_FLAGS='-buildmod pie'
+		export EXTRA_LDFLAGS='-extldflags "-fno-PIC -static"'
+
+		# Reset build flags to nothing if we want a dynbinary
+		if [ "$1" == "dynamic" ]; then
+			export BUILDTAGS=''
+			export EXTRA_FLAGS=''
+			export EXTRA_LDFLAGS=''
 		fi
 
 		make

--- a/components/engine/hack/dockerfile/install/containerd.installer
+++ b/components/engine/hack/dockerfile/install/containerd.installer
@@ -15,7 +15,7 @@ install_containerd() {
 	(
 
 		export BUILDTAGS='static_build netgo'
-		export EXTRA_FLAGS='-buildmod pie'
+		export EXTRA_FLAGS='-buildmode=pie'
 		export EXTRA_LDFLAGS='-extldflags "-fno-PIC -static"'
 
 		# Reset build flags to nothing if we want a dynbinary

--- a/components/engine/hack/dockerfile/install/proxy.installer
+++ b/components/engine/hack/dockerfile/install/proxy.installer
@@ -23,6 +23,7 @@ install_proxy() {
 
 install_proxy_dynamic() {
 	export PROXY_LDFLAGS="-linkmode=external" install_proxy
+	export BUILD_MODE="-buildmode=pie"
 	_install_proxy
 }
 
@@ -31,7 +32,7 @@ _install_proxy() {
 	git clone https://github.com/docker/libnetwork.git "$GOPATH/src/github.com/docker/libnetwork"
 	cd "$GOPATH/src/github.com/docker/libnetwork"
 	git checkout -q "$LIBNETWORK_COMMIT"
-	go build -buildmode=pie -ldflags="$PROXY_LDFLAGS" -o ${PREFIX}/docker-proxy github.com/docker/libnetwork/cmd/proxy
+	go build $BUILD_MODE -ldflags="$PROXY_LDFLAGS" -o ${PREFIX}/docker-proxy github.com/docker/libnetwork/cmd/proxy
 }
 
 

--- a/components/engine/hack/dockerfile/install/runc.installer
+++ b/components/engine/hack/dockerfile/install/runc.installer
@@ -11,7 +11,12 @@ install_runc() {
 	git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc"
 	cd "$GOPATH/src/github.com/opencontainers/runc"
 	git checkout -q "$RUNC_COMMIT"
-	make BUILDTAGS="$RUNC_BUILDTAGS" $1
+	if [ -z "$1" ]; then
+		target=static
+	else
+		target="$1"
+	fi
+	make BUILDTAGS="$RUNC_BUILDTAGS" "$target"
 	mkdir -p ${PREFIX}
 	cp runc ${PREFIX}/docker-runc
 }


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/36518 for 18.03

```
git checkout -b 18.03-fix_static_builds upstream/18.03

git cherry-pick -s -S -x -Xsubtree=components/engine 63c7bb24637fdbfd905096ecc75b435ecefd31e9
git cherry-pick -s -S -x -Xsubtree=components/engine 5e4885b9afb1de30133627ce751af2c0e7b72a4e
```

no conflicts


ping @seemethere @andrewhsu @vdemeester PTAL