### PR TITLE
[18.03] backport daemon/setMounts(): do not make /dev/shm ro

### DIFF
--- a/components/engine/daemon/oci_linux.go
+++ b/components/engine/daemon/oci_linux.go
@@ -667,7 +667,7 @@ func setMounts(daemon *Daemon, s *specs.Spec, c *container.Container, mounts []c
 	if s.Root.Readonly {
 		for i, m := range s.Mounts {
 			switch m.Destination {
-			case "/proc", "/dev/pts", "/dev/mqueue", "/dev":
+			case "/proc", "/dev/pts", "/dev/shm", "/dev/mqueue", "/dev":
 				continue
 			}
 			if _, ok := userMounts[m.Destination]; !ok {


### PR DESCRIPTION
Backport of https://github.com/moby/moby/pull/36526 for 18.03 (fixes https://github.com/moby/moby/issues/36503)

```
git checkout -b 18.03-backport-ipc-ro upstream/18.03
git cherry-pick -s -S -x -Xsubtree=components/engine cad74056c09f6276b0f4a996a1511553177cd3d7
git cherry-pick -s -S -x -Xsubtree=components/engine 33dd562e3acff71ee18a2543d14fcbecf9bf0e62
```

no conflicts