### PR TITLE
[18.03] [integration] skip ppc64le oom tests for now

### DIFF
--- a/components/engine/integration-cli/docker_cli_events_unix_test.go
+++ b/components/engine/integration-cli/docker_cli_events_unix_test.go
@@ -49,7 +49,7 @@ func (s *DockerSuite) TestEventsRedirectStdout(c *check.C) {
 }
 
 func (s *DockerSuite) TestEventsOOMDisableFalse(c *check.C) {
-	testRequires(c, DaemonIsLinux, oomControl, memoryLimitSupport, swapMemorySupport)
+	testRequires(c, DaemonIsLinux, oomControl, memoryLimitSupport, swapMemorySupport, NotPpc64le)
 
 	errChan := make(chan error)
 	go func() {
@@ -79,7 +79,7 @@ func (s *DockerSuite) TestEventsOOMDisableFalse(c *check.C) {
 }
 
 func (s *DockerSuite) TestEventsOOMDisableTrue(c *check.C) {
-	testRequires(c, DaemonIsLinux, oomControl, memoryLimitSupport, NotArm, swapMemorySupport)
+	testRequires(c, DaemonIsLinux, oomControl, memoryLimitSupport, NotArm, swapMemorySupport, NotPpc64le)
 
 	errChan := make(chan error)
 	observer, err := newEventObserver(c)

--- a/components/engine/integration-cli/docker_cli_run_unix_test.go
+++ b/components/engine/integration-cli/docker_cli_run_unix_test.go
@@ -615,7 +615,7 @@ func (s *DockerSuite) TestRunWithInvalidPathforBlkioDeviceWriteIOps(c *check.C) 
 }
 
 func (s *DockerSuite) TestRunOOMExitCode(c *check.C) {
-	testRequires(c, memoryLimitSupport, swapMemorySupport)
+	testRequires(c, memoryLimitSupport, swapMemorySupport, NotPpc64le)
 	errChan := make(chan error)
 	go func() {
 		defer close(errChan)


### PR DESCRIPTION
cherry-pick of https://github.com/moby/moby/pull/36539 for the 18.03 branch

```
git checkout -b 18.03-skip-oom-tests-ppc64le upstream/18.03
git cherry-pick -s -S -x -Xsubtree=components/engine 620ddc78a1437feaa42f40853ef586d268991620
```

no conflicts


These tests were enabled by changing a config option on the ci
machines, instead of from a patch, so let me disable them
for now on ppc64le and open up another patch to enable them, where I can find
out what the issues are with them.

Signed-off-by: Christopher Jones <tophj@linux.vnet.ibm.com>
(cherry picked from commit 620ddc78a1437feaa42f40853ef586d268991620)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

Please do not send pull requests to this docker/docker-ce repository.

We do, however, take contributions gladly.

See https://github.com/docker/docker-ce/blob/master/CONTRIBUTING.md

Thanks!
