### PR TITLE
[18.03] Fix automatic removal of ingress sandbox when last service leaves

### DIFF
--- a/components/engine/daemon/network.go
+++ b/components/engine/daemon/network.go
@@ -222,6 +222,8 @@ func (daemon *Daemon) releaseIngress(id string) {
 		return
 	}
 
+	daemon.deleteLoadBalancerSandbox(n)
+
 	if err := n.Delete(); err != nil {
 		logrus.Errorf("Failed to delete ingress network %s: %v", n.ID(), err)
 		return

--- a/components/engine/vendor.conf
+++ b/components/engine/vendor.conf
@@ -33,7 +33,7 @@ github.com/tonistiigi/fsutil dea3a0da73aee887fc02142d995be764106ac5e2
 #get libnetwork packages
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy accordingly
-github.com/docker/libnetwork ed2130d117c11c542327b4d5216a5db36770bc65
+github.com/docker/libnetwork 3aca383eb555510f3f17696f9505f7bfbd25f0e5
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/components/engine/vendor/github.com/docker/libnetwork/config/config.go
+++ b/components/engine/vendor/github.com/docker/libnetwork/config/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/libkv/store"
 	"github.com/docker/libnetwork/cluster"
 	"github.com/docker/libnetwork/datastore"
+	"github.com/docker/libnetwork/ipamutils"
 	"github.com/docker/libnetwork/netlabel"
 	"github.com/docker/libnetwork/osl"
 	"github.com/sirupsen/logrus"
@@ -40,6 +41,7 @@ type DaemonCfg struct {
 	DriverCfg              map[string]interface{}
 	ClusterProvider        cluster.Provider
 	NetworkControlPlaneMTU int
+	DefaultAddressPool     []*ipamutils.NetworkToSplit
 }
 
 // ClusterCfg represents cluster configuration
@@ -107,6 +109,13 @@ func OptionDefaultDriver(dd string) Option {
 	return func(c *Config) {
 		logrus.Debugf("Option DefaultDriver: %s", dd)
 		c.Daemon.DefaultDriver = strings.TrimSpace(dd)
+	}
+}
+
+// OptionDefaultAddressPoolConfig function returns an option setter for default address pool
+func OptionDefaultAddressPoolConfig(addressPool []*ipamutils.NetworkToSplit) Option {
+	return func(c *Config) {
+		c.Daemon.DefaultAddressPool = addressPool
 	}
 }
 

--- a/components/engine/vendor/github.com/docker/libnetwork/controller.go
+++ b/components/engine/vendor/github.com/docker/libnetwork/controller.go
@@ -222,7 +222,7 @@ func New(cfgOptions ...config.Option) (NetworkController, error) {
 		}
 	}
 
-	if err = initIPAMDrivers(drvRegistry, nil, c.getStore(datastore.GlobalScope)); err != nil {
+	if err = initIPAMDrivers(drvRegistry, nil, c.getStore(datastore.GlobalScope), c.cfg.Daemon.DefaultAddressPool); err != nil {
 		return nil, err
 	}
 

--- a/components/engine/vendor/github.com/docker/libnetwork/drivers/bridge/bridge.go
+++ b/components/engine/vendor/github.com/docker/libnetwork/drivers/bridge/bridge.go
@@ -782,7 +782,9 @@ func (d *driver) deleteNetwork(nid string) error {
 			logrus.Warn(err)
 		}
 		if link, err := d.nlh.LinkByName(ep.srcName); err == nil {
-			d.nlh.LinkDel(link)
+			if err := d.nlh.LinkDel(link); err != nil {
+				logrus.WithError(err).Errorf("Failed to delete interface (%s)'s link on endpoint (%s) delete", ep.srcName, ep.id)
+			}
 		}
 
 		if err := d.storeDelete(ep); err != nil {
@@ -969,7 +971,9 @@ func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo,
 	}
 	defer func() {
 		if err != nil {
-			d.nlh.LinkDel(host)
+			if err := d.nlh.LinkDel(host); err != nil {
+				logrus.WithError(err).Warnf("Failed to delete host side interface (%s)'s link", hostIfName)
+			}
 		}
 	}()
 
@@ -980,7 +984,9 @@ func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo,
 	}
 	defer func() {
 		if err != nil {
-			d.nlh.LinkDel(sbox)
+			if err := d.nlh.LinkDel(sbox); err != nil {
+				logrus.WithError(err).Warnf("Failed to delete sandbox side interface (%s)'s link", containerIfName)
+			}
 		}
 	}()
 
@@ -1117,7 +1123,9 @@ func (d *driver) DeleteEndpoint(nid, eid string) error {
 	// Try removal of link. Discard error: it is a best effort.
 	// Also make sure defer does not see this error either.
 	if link, err := d.nlh.LinkByName(ep.srcName); err == nil {
-		d.nlh.LinkDel(link)
+		if err := d.nlh.LinkDel(link); err != nil {
+			logrus.WithError(err).Errorf("Failed to delete interface (%s)'s link on endpoint (%s) delete", ep.srcName, ep.id)
+		}
 	}
 
 	if err := d.storeDelete(ep); err != nil {

--- a/components/engine/vendor/github.com/docker/libnetwork/drivers/ipvlan/ipvlan_endpoint.go
+++ b/components/engine/vendor/github.com/docker/libnetwork/drivers/ipvlan/ipvlan_endpoint.go
@@ -76,7 +76,9 @@ func (d *driver) DeleteEndpoint(nid, eid string) error {
 		return fmt.Errorf("endpoint id %q not found", eid)
 	}
 	if link, err := ns.NlHandle().LinkByName(ep.srcName); err == nil {
-		ns.NlHandle().LinkDel(link)
+		if err := ns.NlHandle().LinkDel(link); err != nil {
+			logrus.WithError(err).Warnf("Failed to delete interface (%s)'s link on endpoint (%s) delete", ep.srcName, ep.id)
+		}
 	}
 
 	if err := d.storeDelete(ep); err != nil {

--- a/components/engine/vendor/github.com/docker/libnetwork/drivers/ipvlan/ipvlan_network.go
+++ b/components/engine/vendor/github.com/docker/libnetwork/drivers/ipvlan/ipvlan_network.go
@@ -150,7 +150,9 @@ func (d *driver) DeleteNetwork(nid string) error {
 	}
 	for _, ep := range n.endpoints {
 		if link, err := ns.NlHandle().LinkByName(ep.srcName); err == nil {
-			ns.NlHandle().LinkDel(link)
+			if err := ns.NlHandle().LinkDel(link); err != nil {
+				logrus.WithError(err).Warnf("Failed to delete interface (%s)'s link on endpoint (%s) delete", ep.srcName, ep.id)
+			}
 		}
 
 		if err := d.storeDelete(ep); err != nil {

--- a/components/engine/vendor/github.com/docker/libnetwork/drivers/macvlan/macvlan_endpoint.go
+++ b/components/engine/vendor/github.com/docker/libnetwork/drivers/macvlan/macvlan_endpoint.go
@@ -81,7 +81,9 @@ func (d *driver) DeleteEndpoint(nid, eid string) error {
 		return fmt.Errorf("endpoint id %q not found", eid)
 	}
 	if link, err := ns.NlHandle().LinkByName(ep.srcName); err == nil {
-		ns.NlHandle().LinkDel(link)
+		if err := ns.NlHandle().LinkDel(link); err != nil {
+			logrus.WithError(err).Warnf("Failed to delete interface (%s)'s link on endpoint (%s) delete", ep.srcName, ep.id)
+		}
 	}
 
 	if err := d.storeDelete(ep); err != nil {

--- a/components/engine/vendor/github.com/docker/libnetwork/drivers/macvlan/macvlan_network.go
+++ b/components/engine/vendor/github.com/docker/libnetwork/drivers/macvlan/macvlan_network.go
@@ -154,7 +154,9 @@ func (d *driver) DeleteNetwork(nid string) error {
 	}
 	for _, ep := range n.endpoints {
 		if link, err := ns.NlHandle().LinkByName(ep.srcName); err == nil {
-			ns.NlHandle().LinkDel(link)
+			if err := ns.NlHandle().LinkDel(link); err != nil {
+				logrus.WithError(err).Warnf("Failed to delete interface (%s)'s link on endpoint (%s) delete", ep.srcName, ep.id)
+			}
 		}
 
 		if err := d.storeDelete(ep); err != nil {

--- a/components/engine/vendor/github.com/docker/libnetwork/drivers/overlay/ov_network.go
+++ b/components/engine/vendor/github.com/docker/libnetwork/drivers/overlay/ov_network.go
@@ -242,8 +242,10 @@ func (d *driver) DeleteNetwork(nid string) error {
 
 	for _, ep := range n.endpoints {
 		if ep.ifName != "" {
-			if link, err := ns.NlHandle().LinkByName(ep.ifName); err != nil {
-				ns.NlHandle().LinkDel(link)
+			if link, err := ns.NlHandle().LinkByName(ep.ifName); err == nil {
+				if err := ns.NlHandle().LinkDel(link); err != nil {
+					logrus.WithError(err).Warnf("Failed to delete interface (%s)'s link on endpoint (%s) delete", ep.ifName, ep.id)
+				}
 			}
 		}
 

--- a/components/engine/vendor/github.com/docker/libnetwork/drivers_ipam.go
+++ b/components/engine/vendor/github.com/docker/libnetwork/drivers_ipam.go
@@ -6,9 +6,11 @@ import (
 	builtinIpam "github.com/docker/libnetwork/ipams/builtin"
 	nullIpam "github.com/docker/libnetwork/ipams/null"
 	remoteIpam "github.com/docker/libnetwork/ipams/remote"
+	"github.com/docker/libnetwork/ipamutils"
 )
 
-func initIPAMDrivers(r *drvregistry.DrvRegistry, lDs, gDs interface{}) error {
+func initIPAMDrivers(r *drvregistry.DrvRegistry, lDs, gDs interface{}, addressPool []*ipamutils.NetworkToSplit) error {
+	builtinIpam.SetDefaultIPAddressPool(addressPool)
 	for _, fn := range [](func(ipamapi.Callback, interface{}, interface{}) error){
 		builtinIpam.Init,
 		remoteIpam.Init,

--- a/components/engine/vendor/github.com/docker/libnetwork/ipams/builtin/builtin_unix.go
+++ b/components/engine/vendor/github.com/docker/libnetwork/ipams/builtin/builtin_unix.go
@@ -11,6 +11,11 @@ import (
 	"github.com/docker/libnetwork/ipamutils"
 )
 
+var (
+	// defaultAddressPool Stores user configured subnet list
+	defaultAddressPool []*ipamutils.NetworkToSplit
+)
+
 // Init registers the built-in ipam service with libnetwork
 func Init(ic ipamapi.Callback, l, g interface{}) error {
 	var (
@@ -30,7 +35,7 @@ func Init(ic ipamapi.Callback, l, g interface{}) error {
 		}
 	}
 
-	ipamutils.InitNetworks()
+	ipamutils.InitNetworks(GetDefaultIPAddressPool())
 
 	a, err := ipam.NewAllocator(localDs, globalDs)
 	if err != nil {
@@ -40,4 +45,14 @@ func Init(ic ipamapi.Callback, l, g interface{}) error {
 	cps := &ipamapi.Capability{RequiresRequestReplay: true}
 
 	return ic.RegisterIpamDriverWithCapabilities(ipamapi.DefaultIPAM, a, cps)
+}
+
+// SetDefaultIPAddressPool stores default address pool.
+func SetDefaultIPAddressPool(addressPool []*ipamutils.NetworkToSplit) {
+	defaultAddressPool = addressPool
+}
+
+// GetDefaultIPAddressPool returns default address pool.
+func GetDefaultIPAddressPool() []*ipamutils.NetworkToSplit {
+	return defaultAddressPool
 }

--- a/components/engine/vendor/github.com/docker/libnetwork/ipams/builtin/builtin_windows.go
+++ b/components/engine/vendor/github.com/docker/libnetwork/ipams/builtin/builtin_windows.go
@@ -13,6 +13,11 @@ import (
 	windowsipam "github.com/docker/libnetwork/ipams/windowsipam"
 )
 
+var (
+	// defaultAddressPool Stores user configured subnet list
+	defaultAddressPool []*ipamutils.NetworkToSplit
+)
+
 // InitDockerDefault registers the built-in ipam service with libnetwork
 func InitDockerDefault(ic ipamapi.Callback, l, g interface{}) error {
 	var (
@@ -32,7 +37,7 @@ func InitDockerDefault(ic ipamapi.Callback, l, g interface{}) error {
 		}
 	}
 
-	ipamutils.InitNetworks()
+	ipamutils.InitNetworks(nil)
 
 	a, err := ipam.NewAllocator(localDs, globalDs)
 	if err != nil {
@@ -54,4 +59,14 @@ func Init(ic ipamapi.Callback, l, g interface{}) error {
 	}
 
 	return initFunc(ic, l, g)
+}
+
+// SetDefaultIPAddressPool stores default address pool .
+func SetDefaultIPAddressPool(addressPool []*ipamutils.NetworkToSplit) {
+	defaultAddressPool = addressPool
+}
+
+// GetDefaultIPAddressPool returns default address pool .
+func GetDefaultIPAddressPool() []*ipamutils.NetworkToSplit {
+	return defaultAddressPool
 }

--- a/components/engine/vendor/github.com/docker/libnetwork/network.go
+++ b/components/engine/vendor/github.com/docker/libnetwork/network.go
@@ -959,7 +959,7 @@ func (n *network) delete(force bool) error {
 
 	if len(n.loadBalancerIP) != 0 {
 		endpoints := n.Endpoints()
-		if force || len(endpoints) == 1 {
+		if force || (len(endpoints) == 1 && !n.ingress) {
 			n.deleteLoadBalancerSandbox()
 		}
 		//Reload the network from the store to update the epcnt.

--- a/components/engine/vendor/github.com/docker/libnetwork/service_common.go
+++ b/components/engine/vendor/github.com/docker/libnetwork/service_common.go
@@ -9,6 +9,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const maxSetStringLen = 350
+
 func (c *controller) addEndpointNameResolution(svcName, svcID, nID, eID, containerName string, vip net.IP, serviceAliases, taskAliases []string, ip net.IP, addService bool, method string) error {
 	n, err := c.NetworkByID(nID)
 	if err != nil {
@@ -285,7 +287,10 @@ func (c *controller) addServiceBinding(svcName, svcID, nID, eID, containerName s
 	ok, entries := s.assignIPToEndpoint(ip.String(), eID)
 	if !ok || entries > 1 {
 		setStr, b := s.printIPToEndpoint(ip.String())
-		logrus.Warnf("addServiceBinding %s possible trainsient state ok:%t entries:%d set:%t %s", eID, ok, entries, b, setStr)
+		if len(setStr) > maxSetStringLen {
+			setStr = setStr[:maxSetStringLen]
+		}
+		logrus.Warnf("addServiceBinding %s possible transient state ok:%t entries:%d set:%t %s", eID, ok, entries, b, setStr)
 	}
 
 	// Add loadbalancer service and backend in all sandboxes in
@@ -353,7 +358,10 @@ func (c *controller) rmServiceBinding(svcName, svcID, nID, eID, containerName st
 	ok, entries := s.removeIPToEndpoint(ip.String(), eID)
 	if !ok || entries > 0 {
 		setStr, b := s.printIPToEndpoint(ip.String())
-		logrus.Warnf("rmServiceBinding %s possible trainsient state ok:%t entries:%d set:%t %s", eID, ok, entries, b, setStr)
+		if len(setStr) > maxSetStringLen {
+			setStr = setStr[:maxSetStringLen]
+		}
+		logrus.Warnf("rmServiceBinding %s possible transient state ok:%t entries:%d set:%t %s", eID, ok, entries, b, setStr)
 	}
 
 	// Remove loadbalancer service(if needed) and backend in all

--- a/components/engine/vendor/github.com/docker/libnetwork/vendor.conf
+++ b/components/engine/vendor/github.com/docker/libnetwork/vendor.conf
@@ -1,5 +1,5 @@
 github.com/Azure/go-ansiterm d6e3b3328b783f23731bc4d058875b0371ff8109
-github.com/BurntSushi/toml f706d00e3de6abe700c994cdd545a1a4915af060
+github.com/BurntSushi/toml a368813c5e648fee92e5f6c30e3944ff9d5e8895
 github.com/Microsoft/go-winio v0.4.5
 github.com/Microsoft/hcsshim v0.6.5
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec


### PR DESCRIPTION
Backport of https://github.com/moby/moby/pull/36538 / https://github.com/docker/libnetwork/pull/2101 for 18.03

```
git checkout -b 18.03-ingress-fix upstream/18.03

git cherry-pick -s -S -x -Xsubtree=components/engine 805b6a7f749a6c7cbb237e21ee7260d536621808
git cherry-pick -s -S -x -Xsubtree=components/engine 3da4ebf355d3494d1403b2878a1ae6958b2724e9
git cherry-pick -s -S -x -Xsubtree=components/engine bebad150c9c3bc6eb63758c10ef24b9298ecf6e2
```

no conflicts


ping @ctelfer @fcrisciani @brawong @vdemeester PTAL