### PR TITLE
[18.03] Update libnetwork with fixes for duplicate IP addresses

### DIFF
--- a/components/engine/hack/dockerfile/install/proxy.installer
+++ b/components/engine/hack/dockerfile/install/proxy.installer
@@ -3,7 +3,7 @@
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-LIBNETWORK_COMMIT=ed2130d117c11c542327b4d5216a5db36770bc65
+LIBNETWORK_COMMIT=8892d7537c67232591f1f3af60587e3e77e61d41
 
 install_proxy() {
 	case "$1" in

--- a/components/engine/vendor.conf
+++ b/components/engine/vendor.conf
@@ -25,7 +25,7 @@ github.com/google/go-cmp v0.1.0
 
 github.com/RackSec/srslog 456df3a81436d29ba874f3590eeeee25d666f8a5
 github.com/imdario/mergo 0.2.1
-golang.org/x/sync de49d9dcd27d4f764488181bea099dfe6179bcf0
+golang.org/x/sync fd80eb99c8f653c847d294a001bdf2a3a6f768f5
 
 github.com/moby/buildkit aaff9d591ef128560018433fe61beb802e149de8
 github.com/tonistiigi/fsutil dea3a0da73aee887fc02142d995be764106ac5e2
@@ -33,7 +33,7 @@ github.com/tonistiigi/fsutil dea3a0da73aee887fc02142d995be764106ac5e2
 #get libnetwork packages
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy accordingly
-github.com/docker/libnetwork 3aca383eb555510f3f17696f9505f7bfbd25f0e5
+github.com/docker/libnetwork 8892d7537c67232591f1f3af60587e3e77e61d41
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/components/engine/vendor/github.com/docker/libnetwork/ipam/allocator.go
+++ b/components/engine/vendor/github.com/docker/libnetwork/ipam/allocator.go
@@ -402,15 +402,15 @@ func (a *Allocator) getPredefinedPool(as string, ipV6 bool) (*net.IPNet, error) 
 			continue
 		}
 		aSpace.Lock()
-		_, ok := aSpace.subnets[SubnetKey{AddressSpace: as, Subnet: nw.String()}]
-		aSpace.Unlock()
-		if ok {
+		if _, ok := aSpace.subnets[SubnetKey{AddressSpace: as, Subnet: nw.String()}]; ok {
+			aSpace.Unlock()
 			continue
 		}
-
 		if !aSpace.contains(as, nw) {
+			aSpace.Unlock()
 			return nw, nil
 		}
+		aSpace.Unlock()
 	}
 
 	return nil, types.NotFoundErrorf("could not find an available, non-overlapping IPv%d address pool among the defaults to assign to the network", v)

--- a/components/engine/vendor/github.com/docker/libnetwork/vendor.conf
+++ b/components/engine/vendor/github.com/docker/libnetwork/vendor.conf
@@ -50,5 +50,6 @@ github.com/vishvananda/netns 604eaf189ee867d8c147fafc28def2394e878d25
 golang.org/x/crypto 558b6879de74bc843225cde5686419267ff707ca
 golang.org/x/net 7dcfb8076726a3fdd9353b6b8a1f1b6be6811bd6
 golang.org/x/sys 07c182904dbd53199946ba614a412c61d3c548f5
+golang.org/x/sync fd80eb99c8f653c847d294a001bdf2a3a6f768f5
 github.com/pkg/errors 839d9e913e063e28dfd0e6c7b7512793e0a48be9
 github.com/ishidawataru/sctp 07191f837fedd2f13d1ec7b5f885f0f3ec54b1cb

--- a/components/engine/vendor/golang.org/x/sync/README
+++ b/components/engine/vendor/golang.org/x/sync/README
@@ -1,2 +1,0 @@
-This repository provides Go concurrency primitives in addition to the
-ones provided by the language and "sync" and "sync/atomic" packages.

--- a/components/engine/vendor/golang.org/x/sync/README.md
+++ b/components/engine/vendor/golang.org/x/sync/README.md
@@ -1,0 +1,18 @@
+# Go Sync
+
+This repository provides Go concurrency primitives in addition to the
+ones provided by the language and "sync" and "sync/atomic" packages.
+
+## Download/Install
+
+The easiest way to install is to run `go get -u golang.org/x/sync`. You can
+also manually git clone the repository to `$GOPATH/src/golang.org/x/sync`.
+
+## Report Issues / Send Patches
+
+This repository uses Gerrit for code changes. To learn how to submit changes to
+this repository, see https://golang.org/doc/contribute.html.
+
+The main issue tracker for the sync repository is located at
+https://github.com/golang/go/issues. Prefix your issue with "x/sync:" in the
+subject line, so it is easy to find.


### PR DESCRIPTION
cherry-pick of https://github.com/moby/moby/pull/36589 for 18.03

```
git checkout -b 18.03-fix-duplicate-ip-issues upstream/18.03
git cherry-pick -s -S -x -Xsubtree=components/engine 55e0fe24db68b16edccb2fa49c3b1b9d3a9ce58c
```

no conflicts

This updates libnetwork to 8892d7537c67232591f1f3af60587e3e77e61d41 to bring in
IPAM fixes for duplicate IP addresses.

- IPAM tests (libnetwork PR 2104) (no changes in vendored files)
- Fix for Duplicate IP issues  (libnetwork PR 2105)

Also bump golang/x/sync to match libnetwork (no code-changes, other
than the README being updated)

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
(cherry picked from commit 55e0fe24db68b16edccb2fa49c3b1b9d3a9ce58c)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

Please do not send pull requests to this docker/docker-ce repository.

We do, however, take contributions gladly.

See https://github.com/docker/docker-ce/blob/master/CONTRIBUTING.md

Thanks!
