### PR TITLE
[18.03] Ensure a hijacked connection implements CloseWrite whenever its underlying

### DIFF
--- a/components/engine/client/hijack.go
+++ b/components/engine/client/hijack.go
@@ -192,7 +192,7 @@ func (cli *Client) setupHijackConn(req *http.Request, proto string) (net.Conn, e
 		// object that implements CloseWrite iff the underlying connection
 		// implements it.
 		if _, ok := c.(types.CloseWriter); ok {
-			c = &hijackedConnCloseWriter{c, br}
+			c = &hijackedConnCloseWriter{&hijackedConn{c, br}}
 		} else {
 			c = &hijackedConn{c, br}
 		}
@@ -220,7 +220,9 @@ func (c *hijackedConn) Read(b []byte) (int, error) {
 // CloseWrite().  It is returned by setupHijackConn in the case that a) there
 // was already buffered data in the http layer when Hijack() was called, and b)
 // the underlying net.Conn *does* implement CloseWrite().
-type hijackedConnCloseWriter hijackedConn
+type hijackedConnCloseWriter struct {
+	*hijackedConn
+}
 
 var _ types.CloseWriter = &hijackedConnCloseWriter{}
 


### PR DESCRIPTION
connection does.  If this isn't done, then a container listening on stdin won't
receive an EOF when the client closes the stream at their end.


cherry-pick of https://github.com/moby/moby/pull/36517 for 18.03 (fixes https://github.com/moby/moby/issues/36516 for 18.03)

```
git checkout -b 18.03-missing_closewrite upstream/18.03
git cherry-pick -s -S -x -Xsubtree=components/engine 37983921c90b468cafd3ba2ca2574fb81cafe5a7
git cherry-pick -s -S -x -Xsubtree=components/engine f094a05e260d8748f0fd2018a8a908b4189e454d
```

no conflicts