### PR TITLE
[18.03] Update libnetwork to fix stale HNS endpoints on Windows

### DIFF
--- a/components/engine/hack/dockerfile/install/proxy.installer
+++ b/components/engine/hack/dockerfile/install/proxy.installer
@@ -3,7 +3,7 @@
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-LIBNETWORK_COMMIT=8892d7537c67232591f1f3af60587e3e77e61d41
+LIBNETWORK_COMMIT=1b91bc94094ecfdae41daa465cc0c8df37dfb3dd
 
 install_proxy() {
 	case "$1" in

--- a/components/engine/vendor.conf
+++ b/components/engine/vendor.conf
@@ -33,7 +33,7 @@ github.com/tonistiigi/fsutil dea3a0da73aee887fc02142d995be764106ac5e2
 #get libnetwork packages
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy accordingly
-github.com/docker/libnetwork 8892d7537c67232591f1f3af60587e3e77e61d41
+github.com/docker/libnetwork 1b91bc94094ecfdae41daa465cc0c8df37dfb3dd
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec


### PR DESCRIPTION
backport:
* https://github.com/moby/moby/pull/36603 Update libnetwork to fix stale HNS endpoints on Windows

with cherry-pick of https://github.com/moby/moby/pull/36603/commits/fb364f0:
```
$ git cherry-pick -s -x -Xsubtree=components/engine fb364f0
```

no conflicts.