### PR TITLE
[18.03] Fix AppArmor not being applied to Exec processes

### DIFF
--- a/components/engine/daemon/exec_linux.go
+++ b/components/engine/daemon/exec_linux.go
@@ -34,6 +34,8 @@ func (daemon *Daemon) execSetPlatformOpt(c *container.Container, ec *exec.Config
 		if c.AppArmorProfile != "" {
 			appArmorProfile = c.AppArmorProfile
 		} else if c.HostConfig.Privileged {
+			// `docker exec --privileged` does not currently disable AppArmor
+			// profiles. Privileged configuration of the container is inherited
 			appArmorProfile = "unconfined"
 		} else {
 			appArmorProfile = "docker-default"
@@ -50,6 +52,7 @@ func (daemon *Daemon) execSetPlatformOpt(c *container.Container, ec *exec.Config
 				return err
 			}
 		}
+		p.ApparmorProfile = appArmorProfile
 	}
 	daemon.setRlimits(&specs.Spec{Process: p}, c)
 	return nil

--- a/components/engine/daemon/exec_linux_test.go
+++ b/components/engine/daemon/exec_linux_test.go
@@ -1,0 +1,53 @@
+// +build linux
+
+package daemon
+
+import (
+	"testing"
+
+	containertypes "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/container"
+	"github.com/docker/docker/daemon/exec"
+	"github.com/gotestyourself/gotestyourself/assert"
+	"github.com/opencontainers/runc/libcontainer/apparmor"
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func TestExecSetPlatformOpt(t *testing.T) {
+	if !apparmor.IsEnabled() {
+		t.Skip("requires AppArmor to be enabled")
+	}
+	d := &Daemon{}
+	c := &container.Container{AppArmorProfile: "my-custom-profile"}
+	ec := &exec.Config{}
+	p := &specs.Process{}
+
+	err := d.execSetPlatformOpt(c, ec, p)
+	assert.NilError(t, err)
+	assert.Equal(t, "my-custom-profile", p.ApparmorProfile)
+}
+
+// TestExecSetPlatformOptPrivileged verifies that `docker exec --privileged`
+// does not disable AppArmor profiles. Exec currently inherits the `Privileged`
+// configuration of the container. See https://github.com/moby/moby/pull/31773#discussion_r105586900
+//
+// This behavior may change in future, but test for the behavior to prevent it
+// from being changed accidentally.
+func TestExecSetPlatformOptPrivileged(t *testing.T) {
+	if !apparmor.IsEnabled() {
+		t.Skip("requires AppArmor to be enabled")
+	}
+	d := &Daemon{}
+	c := &container.Container{AppArmorProfile: "my-custom-profile"}
+	ec := &exec.Config{Privileged: true}
+	p := &specs.Process{}
+
+	err := d.execSetPlatformOpt(c, ec, p)
+	assert.NilError(t, err)
+	assert.Equal(t, "my-custom-profile", p.ApparmorProfile)
+
+	c.HostConfig = &containertypes.HostConfig{Privileged: true}
+	err = d.execSetPlatformOpt(c, ec, p)
+	assert.NilError(t, err)
+	assert.Equal(t, "unconfined", p.ApparmorProfile)
+}


### PR DESCRIPTION
cherry-pick of https://github.com/moby/moby/pull/36466

```
git checkout -b 18.03-fix-exec-apparmor upstream/18.03 
git cherry-pick -s -S -x -Xsubtree=components/engine 8f3308ae10ec9ad0dd4edfb46fde53a0e1e19b34
```

No conflicts


fixes https://github.com/moby/moby/issues/36456



Exec processes do not automatically inherit AppArmor profiles from the container.


This patch sets the AppArmor profile for the exec process.

Before this change:

```bash
apparmor_parser -q -r <<EOF
#include <tunables/global>
profile deny-write flags=(attach_disconnected) {
  #include <abstractions/base>
  file,
  network,
  deny /tmp/** w,
  capability,
}
EOF

docker run -dit --security-opt "apparmor=deny-write" --name aa busybox
```

Running `docker exec` doesn't get the profile applied:

```bash
docker exec aa sh -c 'mkdir /tmp/test'
(no error)
```

With this change:


Running `docker exec` gets the AppArmor profile applied

```bash
docker exec aa sh -c 'mkdir /tmp/test'
mkdir: can't create directory '/tmp/test': Permission denied
```

**- How to verify it**

Build a `.deb` from this PR, using the Docker CE packaging scripts; https://github.com/docker/docker-ce-packaging/tree/master/deb

```bash
make \
  ENGINE_DIR=$GOPATH/src/github.com/docker/docker \
  CLI_DIR=$GOPATH/src/github.com/docker/cli \
  ubuntu-xenial  
```

Which puts the package in `debbuild/ubuntu-xenial`

On an Ubuntu 16.04 machine, install the package:

```bash
dpkg -i ./docker-ce_0.0.0~dev~git20180302.121756.0.dae4588d4-0~ubuntu_amd64.deb
```

Run the reproduction steps above

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```Markdown
* Fix AppArmor profiles not being applied to `docker exec` processes [moby/moby#36466](https://github.com/moby/moby/pull/36466)
```