### PR TITLE
[18.03] Add missing error return for plugin creation.

### DIFF
--- a/components/engine/plugin/manager_linux.go
+++ b/components/engine/plugin/manager_linux.go
@@ -64,6 +64,7 @@ func (pm *Manager) enable(p *v2.Plugin, c *controller, force bool) error {
 				logrus.Warnf("Could not unmount %s: %v", propRoot, err)
 			}
 		}
+		return errors.WithStack(err)
 	}
 	return pm.pluginPostStart(p, c)
 }


### PR DESCRIPTION
cherry-pick of https://github.com/moby/moby/pull/36646 for 18.03.

```
git checkout -b 18.03-err_return upstream/18.03 
git cherry-pick -s -S -x -Xsubtree=components/engine 89a882e2f1706e567a8514209701892b40da7a62 
```

no conflicts