### PR TITLE
[18.04] vendor: update moby to ed7b6428

### DIFF
--- a/components/cli/cli/command/image/trust_test.go
+++ b/components/cli/cli/command/image/trust_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/docker/cli/cli/trust"
 	registrytypes "github.com/docker/docker/api/types/registry"
-	"github.com/docker/docker/registry"
 	"github.com/gotestyourself/gotestyourself/assert"
 	"github.com/theupdateframework/notary/client"
 	"github.com/theupdateframework/notary/passphrase"
@@ -47,8 +46,8 @@ func TestHTTPENVTrustServer(t *testing.T) {
 func TestOfficialTrustServer(t *testing.T) {
 	indexInfo := &registrytypes.IndexInfo{Name: "testserver", Official: true}
 	output, err := trust.Server(indexInfo)
-	if err != nil || output != registry.NotaryServer {
-		t.Fatalf("Expected server to be %s, got %s", registry.NotaryServer, output)
+	if err != nil || output != trust.NotaryServer {
+		t.Fatalf("Expected server to be %s, got %s", trust.NotaryServer, output)
 	}
 }
 

--- a/components/cli/cli/trust/trust.go
+++ b/components/cli/cli/trust/trust.go
@@ -41,6 +41,8 @@ var (
 	ActionsPullOnly = []string{"pull"}
 	// ActionsPushAndPull defines the actions for read-write interactions with a Notary Repository
 	ActionsPushAndPull = []string{"pull", "push"}
+	// NotaryServer is the endpoint serving the Notary trust server
+	NotaryServer = "https://notary.docker.io"
 )
 
 // GetTrustDirectory returns the base trust directory name
@@ -71,7 +73,7 @@ func Server(index *registrytypes.IndexInfo) (string, error) {
 		return s, nil
 	}
 	if index.Official {
-		return registry.NotaryServer, nil
+		return NotaryServer, nil
 	}
 	return "https://" + index.Name, nil
 }

--- a/components/cli/vendor.conf
+++ b/components/cli/vendor.conf
@@ -5,7 +5,7 @@ github.com/coreos/etcd v3.2.1
 github.com/cpuguy83/go-md2man v1.0.8
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
 github.com/docker/distribution edc3ab29cdff8694dd6feb85cfeb4b5f1b38ed9c
-github.com/docker/docker ae7016427f8cba4e4d8fcb979d6ba313ee2c0702
+github.com/docker/docker ed7b6428c133e7c59404251a09b7d6b02fa83cc2
 github.com/docker/docker-credential-helpers 3c90bd29a46b943b2a9842987b58fb91a7c1819b
 # the docker/go package contains a customized version of canonical/json
 # and is used by Notary. The package is periodically rebased on current Go versions.

--- a/components/cli/vendor/github.com/docker/docker/client/hijack.go
+++ b/components/cli/vendor/github.com/docker/docker/client/hijack.go
@@ -192,7 +192,7 @@ func (cli *Client) setupHijackConn(req *http.Request, proto string) (net.Conn, e
 		// object that implements CloseWrite iff the underlying connection
 		// implements it.
 		if _, ok := c.(types.CloseWriter); ok {
-			c = &hijackedConnCloseWriter{c, br}
+			c = &hijackedConnCloseWriter{&hijackedConn{c, br}}
 		} else {
 			c = &hijackedConn{c, br}
 		}
@@ -220,7 +220,9 @@ func (c *hijackedConn) Read(b []byte) (int, error) {
 // CloseWrite().  It is returned by setupHijackConn in the case that a) there
 // was already buffered data in the http layer when Hijack() was called, and b)
 // the underlying net.Conn *does* implement CloseWrite().
-type hijackedConnCloseWriter hijackedConn
+type hijackedConnCloseWriter struct {
+	*hijackedConn
+}
 
 var _ types.CloseWriter = &hijackedConnCloseWriter{}
 

--- a/components/cli/vendor/github.com/docker/docker/pkg/jsonmessage/jsonmessage.go
+++ b/components/cli/vendor/github.com/docker/docker/pkg/jsonmessage/jsonmessage.go
@@ -40,21 +40,17 @@ type JSONProgress struct {
 	// If true, don't show xB/yB
 	HideCounts bool   `json:"hidecounts,omitempty"`
 	Units      string `json:"units,omitempty"`
+	nowFunc    func() time.Time
+	winSize    int
 }
 
 func (p *JSONProgress) String() string {
 	var (
-		width       = 200
+		width       = p.width()
 		pbBox       string
 		numbersBox  string
 		timeLeftBox string
 	)
-
-	ws, err := term.GetWinsize(p.terminalFd)
-	if err == nil {
-		width = int(ws.Width)
-	}
-
 	if p.Current <= 0 && p.Total <= 0 {
 		return ""
 	}
@@ -103,7 +99,7 @@ func (p *JSONProgress) String() string {
 	}
 
 	if p.Current > 0 && p.Start > 0 && percentage < 50 {
-		fromStart := time.Now().UTC().Sub(time.Unix(p.Start, 0))
+		fromStart := p.now().Sub(time.Unix(p.Start, 0))
 		perEntry := fromStart / time.Duration(p.Current)
 		left := time.Duration(p.Total-p.Current) * perEntry
 		left = (left / time.Second) * time.Second
@@ -113,6 +109,28 @@ func (p *JSONProgress) String() string {
 		}
 	}
 	return pbBox + numbersBox + timeLeftBox
+}
+
+// shim for testing
+func (p *JSONProgress) now() time.Time {
+	if p.nowFunc == nil {
+		p.nowFunc = func() time.Time {
+			return time.Now().UTC()
+		}
+	}
+	return p.nowFunc()
+}
+
+// shim for testing
+func (p *JSONProgress) width() int {
+	if p.winSize != 0 {
+		return p.winSize
+	}
+	ws, err := term.GetWinsize(p.terminalFd)
+	if err == nil {
+		return int(ws.Width)
+	}
+	return 200
 }
 
 // JSONMessage defines a message struct. It describes

--- a/components/cli/vendor/github.com/docker/docker/registry/config.go
+++ b/components/cli/vendor/github.com/docker/docker/registry/config.go
@@ -45,9 +45,6 @@ var (
 	// IndexName is the name of the index
 	IndexName = "docker.io"
 
-	// NotaryServer is the endpoint serving the Notary trust server
-	NotaryServer = "https://notary.docker.io"
-
 	// DefaultV2Registry is the URI of the default v2 registry
 	DefaultV2Registry = &url.URL{
 		Scheme: "https",

--- a/components/cli/vendor/github.com/docker/docker/vendor.conf
+++ b/components/cli/vendor/github.com/docker/docker/vendor.conf
@@ -2,7 +2,6 @@
 github.com/Azure/go-ansiterm d6e3b3328b783f23731bc4d058875b0371ff8109
 github.com/Microsoft/hcsshim v0.6.8
 github.com/Microsoft/go-winio v0.4.6
-github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
 github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a
 github.com/go-check/check 4ed411733c5785b40214c70bce814c3a3a689609 https://github.com/cpuguy83/check.git
 github.com/golang/gddo 9b12a26f3fbd7397dee4e20939ddca719d840d2a
@@ -19,10 +18,9 @@ golang.org/x/sys 37707fdb30a5b38865cfb95e5aab41707daec7fd
 github.com/docker/go-units 9e638d38cf6977a37a8ea0078f3ee75a7cdb2dd1
 github.com/docker/go-connections 7beb39f0b969b075d1325fecb092faf27fd357b6
 golang.org/x/text f72d8390a633d5dfb0cc84043294db9f6c935756
-github.com/stretchr/testify 4d4bfba8f1d1027c4fdbe371823030df51419987
 github.com/pmezard/go-difflib v1.0.0
-github.com/gotestyourself/gotestyourself 511344eed30e4384f010579a593dfb442033a692
-github.com/google/go-cmp v0.1.0
+github.com/gotestyourself/gotestyourself cf3a5ab914a2efa8bc838d09f5918c1d44d029
+github.com/google/go-cmp v0.2.0
 
 github.com/RackSec/srslog 456df3a81436d29ba874f3590eeeee25d666f8a5
 github.com/imdario/mergo 0.2.1
@@ -34,7 +32,7 @@ github.com/tonistiigi/fsutil dea3a0da73aee887fc02142d995be764106ac5e2
 #get libnetwork packages
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy accordingly
-github.com/docker/libnetwork 8892d7537c67232591f1f3af60587e3e77e61d41
+github.com/docker/libnetwork 1b91bc94094ecfdae41daa465cc0c8df37dfb3dd
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec
@@ -63,7 +61,7 @@ github.com/ishidawataru/sctp 07191f837fedd2f13d1ec7b5f885f0f3ec54b1cb
 # get graph and distribution packages
 github.com/docker/distribution edc3ab29cdff8694dd6feb85cfeb4b5f1b38ed9c
 github.com/vbatts/tar-split v0.10.2
-github.com/opencontainers/go-digest a6d0ee40d4207ea02364bd3b9e8e77b9159ba1eb
+github.com/opencontainers/go-digest v1.0.0-rc1
 
 # get go-zfs packages
 github.com/mistifyio/go-zfs 22c9b32c84eb0d0c6f4043b6e90fc94073de92fa


### PR DESCRIPTION
backport:
* https://github.com/docker/cli/pull/975 vendor: update moby to ed7b6428

with cherry-pick:
```
$ git cherry-pick -s -x -Xsubtree=components/cli a1cbaa8
```

no conflicts.