### PR TITLE
[18.03] backport Fix error with merge composefile with networks…

### DIFF
--- a/components/cli/cli/compose/loader/merge.go
+++ b/components/cli/cli/compose/loader/merge.go
@@ -61,7 +61,7 @@ func mergeServices(base, override []types.ServiceConfig) ([]types.ServiceConfig,
 	}
 	for name, overrideService := range overrideServices {
 		if baseService, ok := baseServices[name]; ok {
-			if err := mergo.Merge(&baseService, &overrideService, mergo.WithOverride, mergo.WithTransformers(specials)); err != nil {
+			if err := mergo.Merge(&baseService, &overrideService, mergo.WithAppendSlice, mergo.WithOverride, mergo.WithTransformers(specials)); err != nil {
 				return base, errors.Wrapf(err, "cannot merge service %s", name)
 			}
 			baseServices[name] = baseService
@@ -213,21 +213,21 @@ func mapByName(services []types.ServiceConfig) map[string]types.ServiceConfig {
 }
 
 func mergeVolumes(base, override map[string]types.VolumeConfig) (map[string]types.VolumeConfig, error) {
-	err := mergo.Map(&base, &override)
+	err := mergo.Map(&base, &override, mergo.WithOverride)
 	return base, err
 }
 
 func mergeNetworks(base, override map[string]types.NetworkConfig) (map[string]types.NetworkConfig, error) {
-	err := mergo.Map(&base, &override)
+	err := mergo.Map(&base, &override, mergo.WithOverride)
 	return base, err
 }
 
 func mergeSecrets(base, override map[string]types.SecretConfig) (map[string]types.SecretConfig, error) {
-	err := mergo.Map(&base, &override)
+	err := mergo.Map(&base, &override, mergo.WithOverride)
 	return base, err
 }
 
 func mergeConfigs(base, override map[string]types.ConfigObjConfig) (map[string]types.ConfigObjConfig, error) {
-	err := mergo.Map(&base, &override)
+	err := mergo.Map(&base, &override, mergo.WithOverride)
 	return base, err
 }

--- a/components/cli/docs/reference/commandline/stack_deploy.md
+++ b/components/cli/docs/reference/commandline/stack_deploy.md
@@ -81,7 +81,7 @@ configuration and environment-specific overrides, you can provide multiple
 `--compose-file` flags.
 
 ```bash
-$ docker stack deploy --compose-file docker-compose.yml -f docker-compose.prod.yml vossibility
+$ docker stack deploy --compose-file docker-compose.yml -c docker-compose.prod.yml vossibility
 
 Ignoring unsupported options: links
 

--- a/components/cli/vendor.conf
+++ b/components/cli/vendor.conf
@@ -37,7 +37,7 @@ github.com/go-openapi/swag 1d0bd113de87027671077d3c71eb3ac5d7dbba72
 github.com/gregjones/httpcache c1f8028e62adb3d518b823a2f8e6a95c38bdd3aa
 github.com/grpc-ecosystem/grpc-gateway 1a03ca3bad1e1ebadaedd3abb76bc58d4ac8143b
 github.com/howeyc/gopass 3ca23474a7c7203e0a0a070fd33508f6efdb9b3d
-github.com/imdario/mergo ea74e0177b4df59af68c076af5008b427d00d40f
+github.com/imdario/mergo 9d5f1277e9a8ed20c3684bda8fde67c05628518c # v0.3.4
 github.com/inconshreveable/mousetrap 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 github.com/juju/ratelimit 5b9ff866471762aa2ab2dced63c9fb6f53921342
 github.com/json-iterator/go 6240e1e7983a85228f7fd9c3e1b6932d46ec58e2

--- a/components/cli/vendor/github.com/imdario/mergo/README.md
+++ b/components/cli/vendor/github.com/imdario/mergo/README.md
@@ -8,10 +8,11 @@ Also a lovely [comune](http://en.wikipedia.org/wiki/Mergo) (municipality) in the
 
 It is ready for production use. [It is used in several projects by Docker, Google, The Linux Foundation, VMWare, Shopify, etc](https://github.com/imdario/mergo#mergo-in-the-wild).
 
-[![Build Status][1]][2]
 [![GoDoc][3]][4]
 [![GoCard][5]][6]
+[![Build Status][1]][2]
 [![Coverage Status][7]][8]
+[![Sourcegraph][9]][10]
 
 [1]: https://travis-ci.org/imdario/mergo.png
 [2]: https://travis-ci.org/imdario/mergo
@@ -21,18 +22,22 @@ It is ready for production use. [It is used in several projects by Docker, Googl
 [6]: https://goreportcard.com/report/github.com/imdario/mergo
 [7]: https://coveralls.io/repos/github/imdario/mergo/badge.svg?branch=master
 [8]: https://coveralls.io/github/imdario/mergo?branch=master
+[9]: https://sourcegraph.com/github.com/imdario/mergo/-/badge.svg
+[10]: https://sourcegraph.com/github.com/imdario/mergo?badge
 
 ### Latest release
 
-[Release 0.3.2](https://github.com/imdario/mergo/releases/tag/0.3.2) is an important release because it changes `Merge()`and `Map()` signatures to support [transformers](#transformers). An optional/variadic argument has been added, so it won't break existing code.
+[Release v0.3.4](https://github.com/imdario/mergo/releases/tag/v0.3.4).
 
 ### Important note
+
+Please keep in mind that in [0.3.2](//github.com/imdario/mergo/releases/tag/0.3.2) Mergo changed `Merge()`and `Map()` signatures to support [transformers](#transformers). An optional/variadic argument has been added, so it won't break existing code.
 
 If you were using Mergo **before** April 6th 2015, please check your project works as intended after updating your local copy with ```go get -u github.com/imdario/mergo```. I apologize for any issue caused by its previous behavior and any future bug that Mergo could cause (I hope it won't!) in existing projects after the change (release 0.2.0).
 
 ### Donations
 
-If Mergo is useful to you, consider buying me a coffe, a beer or making a monthly donation so I can keep building great free software. :heart_eyes:
+If Mergo is useful to you, consider buying me a coffee, a beer or making a monthly donation so I can keep building great free software. :heart_eyes:
 
 <a href='https://ko-fi.com/B0B58839' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://az743702.vo.msecnd.net/cdn/kofi1.png?v=0' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
 [![Beerpay](https://beerpay.io/imdario/mergo/badge.svg)](https://beerpay.io/imdario/mergo)
@@ -93,7 +98,7 @@ If Mergo is useful to you, consider buying me a coffe, a beer or making a monthl
 
 ## Usage
 
-You can only merge same-type structs with exported fields initialized as zero value of their type and same-types maps. Mergo won't merge unexported (private) fields but will do recursively any exported one. Also maps will be merged recursively except for structs inside maps (because they are not addressable using Go reflection).
+You can only merge same-type structs with exported fields initialized as zero value of their type and same-types maps. Mergo won't merge unexported (private) fields but will do recursively any exported one. It won't merge empty structs value as [they are not considered zero values](https://golang.org/ref/spec#The_zero_value) either. Also maps will be merged recursively except for structs inside maps (because they are not addressable using Go reflection).
 
 ```go
 if err := mergo.Merge(&dst, src); err != nil {
@@ -104,7 +109,7 @@ if err := mergo.Merge(&dst, src); err != nil {
 Also, you can merge overwriting values using the transformer `WithOverride`.
 
 ```go
-if err := mergo.Merge(&dst, src, WithOverride); err != nil {
+if err := mergo.Merge(&dst, src, mergo.WithOverride); err != nil {
     // ...
 }
 ```
@@ -164,6 +169,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/imdario/mergo"
         "reflect"
         "time"
 )
@@ -195,7 +201,7 @@ type Snapshot struct {
 func main() {
 	src := Snapshot{time.Now()}
 	dest := Snapshot{}
-	mergo.Merge(&dest, src, WithTransformers(timeTransfomer{}))
+	mergo.Merge(&dest, src, mergo.WithTransformers(timeTransfomer{}))
 	fmt.Println(dest)
 	// Will print
 	// { 2018-01-12 01:15:00 +0000 UTC m=+0.000000001 }

--- a/components/cli/vendor/github.com/imdario/mergo/map.go
+++ b/components/cli/vendor/github.com/imdario/mergo/map.go
@@ -31,8 +31,8 @@ func isExported(field reflect.StructField) bool {
 // Traverses recursively both values, assigning src's fields values to dst.
 // The map argument tracks comparisons that have already been seen, which allows
 // short circuiting on recursive types.
-func deepMap(dst, src reflect.Value, visited map[uintptr]*visit, depth int, config *config) (err error) {
-	overwrite := config.overwrite
+func deepMap(dst, src reflect.Value, visited map[uintptr]*visit, depth int, config *Config) (err error) {
+	overwrite := config.Overwrite
 	if dst.CanAddr() {
 		addr := dst.UnsafeAddr()
 		h := 17 * addr
@@ -128,23 +128,23 @@ func deepMap(dst, src reflect.Value, visited map[uintptr]*visit, depth int, conf
 // doesn't apply if dst is a map.
 // This is separated method from Merge because it is cleaner and it keeps sane
 // semantics: merging equal types, mapping different (restricted) types.
-func Map(dst, src interface{}, opts ...func(*config)) error {
+func Map(dst, src interface{}, opts ...func(*Config)) error {
 	return _map(dst, src, opts...)
 }
 
-// MapWithOverwrite will do the same as Map except that non-empty dst attributes will be overriden by
+// MapWithOverwrite will do the same as Map except that non-empty dst attributes will be overridden by
 // non-empty src attribute values.
 // Deprecated: Use Map(…) with WithOverride
-func MapWithOverwrite(dst, src interface{}, opts ...func(*config)) error {
+func MapWithOverwrite(dst, src interface{}, opts ...func(*Config)) error {
 	return _map(dst, src, append(opts, WithOverride)...)
 }
 
-func _map(dst, src interface{}, opts ...func(*config)) error {
+func _map(dst, src interface{}, opts ...func(*Config)) error {
 	var (
 		vDst, vSrc reflect.Value
 		err        error
 	)
-	config := &config{}
+	config := &Config{}
 
 	for _, opt := range opts {
 		opt(config)

--- a/components/cli/vendor/github.com/imdario/mergo/merge.go
+++ b/components/cli/vendor/github.com/imdario/mergo/merge.go
@@ -8,7 +8,9 @@
 
 package mergo
 
-import "reflect"
+import (
+	"reflect"
+)
 
 func hasExportedField(dst reflect.Value) (exported bool) {
 	for i, n := 0, dst.NumField(); i < n; i++ {
@@ -22,20 +24,21 @@ func hasExportedField(dst reflect.Value) (exported bool) {
 	return
 }
 
-type config struct {
-	overwrite    bool
-	transformers transformers
+type Config struct {
+	Overwrite    bool
+	AppendSlice  bool
+	Transformers Transformers
 }
 
-type transformers interface {
+type Transformers interface {
 	Transformer(reflect.Type) func(dst, src reflect.Value) error
 }
 
 // Traverses recursively both values, assigning src's fields values to dst.
 // The map argument tracks comparisons that have already been seen, which allows
 // short circuiting on recursive types.
-func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, config *config) (err error) {
-	overwrite := config.overwrite
+func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, config *Config) (err error) {
+	overwrite := config.Overwrite
 
 	if !src.IsValid() {
 		return
@@ -54,8 +57,8 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 		visited[h] = &visit{addr, typ, seen}
 	}
 
-	if config.transformers != nil && !isEmptyValue(dst) {
-		if fn := config.transformers.Transformer(dst.Type()); fn != nil {
+	if config.Transformers != nil && !isEmptyValue(dst) {
+		if fn := config.Transformers.Transformer(dst.Type()); fn != nil {
 			err = fn(dst, src)
 			return
 		}
@@ -75,9 +78,8 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 			}
 		}
 	case reflect.Map:
-		if len(src.MapKeys()) == 0 && !src.IsNil() && len(dst.MapKeys()) == 0 {
+		if dst.IsNil() && !src.IsNil() {
 			dst.Set(reflect.MakeMap(dst.Type()))
-			return
 		}
 		for _, key := range src.MapKeys() {
 			srcElement := src.MapIndex(key)
@@ -130,7 +132,14 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 			}
 		}
 	case reflect.Slice:
-		dst.Set(reflect.AppendSlice(dst, src))
+		if !dst.CanSet() {
+			break
+		}
+		if !isEmptyValue(src) && (overwrite || isEmptyValue(dst)) && !config.AppendSlice {
+			dst.Set(src)
+		} else {
+			dst.Set(reflect.AppendSlice(dst, src))
+		}
 	case reflect.Ptr:
 		fallthrough
 	case reflect.Interface:
@@ -174,36 +183,41 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 // src attributes if they themselves are not empty. dst and src must be valid same-type structs
 // and dst must be a pointer to struct.
 // It won't merge unexported (private) fields and will do recursively any exported field.
-func Merge(dst, src interface{}, opts ...func(*config)) error {
+func Merge(dst, src interface{}, opts ...func(*Config)) error {
 	return merge(dst, src, opts...)
 }
 
 // MergeWithOverwrite will do the same as Merge except that non-empty dst attributes will be overriden by
 // non-empty src attribute values.
 // Deprecated: use Merge(…) with WithOverride
-func MergeWithOverwrite(dst, src interface{}, opts ...func(*config)) error {
+func MergeWithOverwrite(dst, src interface{}, opts ...func(*Config)) error {
 	return merge(dst, src, append(opts, WithOverride)...)
 }
 
 // WithTransformers adds transformers to merge, allowing to customize the merging of some types.
-func WithTransformers(transformers transformers) func(*config) {
-	return func(config *config) {
-		config.transformers = transformers
+func WithTransformers(transformers Transformers) func(*Config) {
+	return func(config *Config) {
+		config.Transformers = transformers
 	}
 }
 
 // WithOverride will make merge override non-empty dst attributes with non-empty src attributes values.
-func WithOverride(config *config) {
-	config.overwrite = true
+func WithOverride(config *Config) {
+	config.Overwrite = true
 }
 
-func merge(dst, src interface{}, opts ...func(*config)) error {
+// WithAppendSlice will make merge append slices instead of overwriting it
+func WithAppendSlice(config *Config) {
+	config.AppendSlice = true
+}
+
+func merge(dst, src interface{}, opts ...func(*Config)) error {
 	var (
 		vDst, vSrc reflect.Value
 		err        error
 	)
 
-	config := &config{}
+	config := &Config{}
 
 	for _, opt := range opts {
 		opt(config)


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/981 and https://github.com/docker/cli/pull/983 for 18.03

```
git checkout -b 18.03-backport-972-fix-merge-network upstream/18.03
git cherry-pick -s -S -x -Xsubtree=components/cli 2ee9635b1e7163aaea285a2f58033575f8b0e4ed
git cherry-pick -s -S -x -Xsubtree=components/cli 0122730faf7136feb020078058537382fcc8413e
git push -u origin 18.03-backport-972-fix-merge-network
```

no conflicts