### PR TITLE
[18.03] [docs] Fix typo in manifest command docs: updated `MANFEST` to `MANIFEST`

### DIFF
--- a/components/cli/cli/command/manifest/create_list.go
+++ b/components/cli/cli/command/manifest/create_list.go
@@ -21,7 +21,7 @@ func newCreateListCommand(dockerCli command.Cli) *cobra.Command {
 	opts := createOpts{}
 
 	cmd := &cobra.Command{
-		Use:   "create MANFEST_LIST MANIFEST [MANIFEST...]",
+		Use:   "create MANIFEST_LIST MANIFEST [MANIFEST...]",
 		Short: "Create a local manifest list for annotating and pushing to a registry",
 		Args:  cli.RequiresMinArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/components/cli/docs/reference/commandline/manifest.md
+++ b/components/cli/docs/reference/commandline/manifest.md
@@ -65,7 +65,7 @@ Options:
 ### manifest create 
 
 ```bash
-Usage:  docker manifest create MANFEST_LIST MANIFEST [MANIFEST...]
+Usage:  docker manifest create MANIFEST_LIST MANIFEST [MANIFEST...]
 
 Create a local manifest list for annotating and pushing to a registry
 


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/978 for 18.03

```
git checkout -b 18.03-backport-fix-manifest-docs-typo upstream/18.03
git cherry-pick -s -S -x -Xsubtree=components/cli 9fa6bd4174a1bedfae8f705e694be477f64a45ce
git push -u origin 18.03-backport-fix-manifest-docs-typo
```

no conflicts