### PR TITLE
[18.03] Fix docker version output alignment

### DIFF
--- a/components/cli/cli/command/system/version.go
+++ b/components/cli/cli/command/system/version.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"runtime"
 	"sort"
+	"text/tabwriter"
 	"text/template"
 	"time"
 
@@ -173,11 +174,12 @@ func runVersion(dockerCli command.Cli, opts *versionOptions) error {
 			})
 		}
 	}
-
-	if err2 := tmpl.Execute(dockerCli.Out(), vd); err2 != nil && err == nil {
+	t := tabwriter.NewWriter(dockerCli.Out(), 15, 1, 1, ' ', 0)
+	if err2 := tmpl.Execute(t, vd); err2 != nil && err == nil {
 		err = err2
 	}
-	dockerCli.Out().Write([]byte{'\n'})
+	t.Write([]byte("\n"))
+	t.Flush()
 	return err
 }
 


### PR DESCRIPTION
Use tabwriter to print the version output

backport of https://github.com/docker/cli/pull/965 for 18.03

```
git checkout -b 18.03-backport-fix-version-output upstream/18.03
git cherry-pick -s -S -x -Xsubtree=components/cli 48eb7a082dfcca6b16a3466a98cd27b04deb07c7
git push -u origin 18.03-backport-fix-version-output
```

no conflicts
