### PR TITLE
[18.03] bump golang to 1.9.5

### DIFF
--- a/components/cli/dockerfiles/Dockerfile.binary-native
+++ b/components/cli/dockerfiles/Dockerfile.binary-native
@@ -1,4 +1,4 @@
-FROM    golang:1.9.4-alpine3.6
+FROM    golang:1.9.5-alpine3.6
 
 RUN     apk add -U git bash coreutils gcc musl-dev
 

--- a/components/cli/dockerfiles/Dockerfile.cross
+++ b/components/cli/dockerfiles/Dockerfile.cross
@@ -1,3 +1,3 @@
-FROM    dockercore/golang-cross:1.9.4@sha256:b8d43ef11ccaa15bec63a1f1fd0c28a0e729074aa62fcfa51f0a5888f3571315
+FROM    dockercore/golang-cross:1.9.5@sha256:4d090b8c2e6d369a48254c882a4e653ba90caaa0b758105da772d9110394d958
 ENV     DISABLE_WARN_OUTSIDE_CONTAINER=1
 WORKDIR /go/src/github.com/docker/cli

--- a/components/cli/dockerfiles/Dockerfile.dev
+++ b/components/cli/dockerfiles/Dockerfile.dev
@@ -1,5 +1,5 @@
 
-FROM    golang:1.9.4-alpine3.6
+FROM    golang:1.9.5-alpine3.6
 
 RUN     apk add -U git make bash coreutils ca-certificates
 

--- a/components/cli/dockerfiles/Dockerfile.lint
+++ b/components/cli/dockerfiles/Dockerfile.lint
@@ -1,4 +1,4 @@
-FROM    golang:1.9.4-alpine3.6
+FROM    golang:1.9.5-alpine3.6
 
 RUN     apk add -U git
 

--- a/components/engine/Dockerfile
+++ b/components/engine/Dockerfile
@@ -97,7 +97,7 @@ RUN apt-get update && apt-get install -y \
 #            will need updating, to avoid errors. Ping #docker-maintainers on IRC
 #            with a heads-up.
 # IMPORTANT: When updating this please note that stdlib archive/tar pkg is vendored
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" \
 	| tar -xzC /usr/local
 

--- a/components/engine/Dockerfile.aarch64
+++ b/components/engine/Dockerfile.aarch64
@@ -74,7 +74,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install Go
 # IMPORTANT: When updating this please note that stdlib archive/tar pkg is vendored
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" \
 	| tar -xzC /usr/local
 

--- a/components/engine/Dockerfile.armhf
+++ b/components/engine/Dockerfile.armhf
@@ -64,7 +64,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install Go
 # IMPORTANT: When updating this please note that stdlib archive/tar pkg is vendored
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" \
 	| tar -xzC /usr/local
 ENV PATH /go/bin:/usr/local/go/bin:$PATH

--- a/components/engine/Dockerfile.e2e
+++ b/components/engine/Dockerfile.e2e
@@ -1,5 +1,5 @@
 ## Step 1: Build tests
-FROM golang:1.9.4-alpine3.6 as builder
+FROM golang:1.9.5-alpine3.6 as builder
 
 RUN apk add --update \
     bash \

--- a/components/engine/Dockerfile.ppc64le
+++ b/components/engine/Dockerfile.ppc64le
@@ -65,7 +65,7 @@ RUN apt-get update && apt-get install -y \
 # Install Go
 # NOTE: official ppc64le go binaries weren't available until go 1.6.4 and 1.7.4
 # IMPORTANT: When updating this please note that stdlib archive/tar pkg is vendored
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" \
 	| tar -xzC /usr/local
 

--- a/components/engine/Dockerfile.s390x
+++ b/components/engine/Dockerfile.s390x
@@ -59,7 +59,7 @@ RUN apt-get update && apt-get install -y \
 	--no-install-recommends
 
 # IMPORTANT: When updating this please note that stdlib archive/tar pkg is vendored
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-s390x.tar.gz" \
 	| tar -xzC /usr/local
 

--- a/components/engine/Dockerfile.simple
+++ b/components/engine/Dockerfile.simple
@@ -42,7 +42,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 #            will need updating, to avoid errors. Ping #docker-maintainers on IRC
 #            with a heads-up.
 # IMPORTANT: When updating this please note that stdlib archive/tar pkg is vendored
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" \
 	| tar -xzC /usr/local
 ENV PATH /go/bin:/usr/local/go/bin:$PATH

--- a/components/engine/Dockerfile.windows
+++ b/components/engine/Dockerfile.windows
@@ -161,7 +161,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.
 #  - FROM_DOCKERFILE is used for detection of building within a container.
-ENV GO_VERSION=1.9.4 `
+ENV GO_VERSION=1.9.5 `
     GIT_VERSION=2.11.1 `
     GOPATH=C:\go `
     FROM_DOCKERFILE=1

--- a/components/engine/contrib/builder/deb/aarch64/debian-jessie/Dockerfile
+++ b/components/engine/contrib/builder/deb/aarch64/debian-jessie/Dockerfile
@@ -7,7 +7,7 @@ FROM aarch64/debian:jessie
 RUN echo deb http://ftp.debian.org/debian jessie-backports main > /etc/apt/sources.list.d/backports.list
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev pkg-config vim-common libsystemd-journal-dev libseccomp-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/components/engine/contrib/builder/deb/aarch64/debian-stretch/Dockerfile
+++ b/components/engine/contrib/builder/deb/aarch64/debian-stretch/Dockerfile
@@ -6,7 +6,7 @@ FROM aarch64/debian:stretch
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev pkg-config vim-common libsystemd-dev libseccomp-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/components/engine/contrib/builder/deb/aarch64/ubuntu-trusty/Dockerfile
+++ b/components/engine/contrib/builder/deb/aarch64/ubuntu-trusty/Dockerfile
@@ -6,7 +6,7 @@ FROM aarch64/ubuntu:trusty
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/components/engine/contrib/builder/deb/aarch64/ubuntu-xenial/Dockerfile
+++ b/components/engine/contrib/builder/deb/aarch64/ubuntu-xenial/Dockerfile
@@ -6,7 +6,7 @@ FROM aarch64/ubuntu:xenial
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev pkg-config vim-common libsystemd-dev libseccomp-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/components/engine/contrib/builder/deb/amd64/debian-jessie/Dockerfile
+++ b/components/engine/contrib/builder/deb/amd64/debian-jessie/Dockerfile
@@ -10,7 +10,7 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev  pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/components/engine/contrib/builder/deb/amd64/debian-stretch/Dockerfile
+++ b/components/engine/contrib/builder/deb/amd64/debian-stretch/Dockerfile
@@ -10,7 +10,7 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/components/engine/contrib/builder/deb/amd64/debian-wheezy/Dockerfile
+++ b/components/engine/contrib/builder/deb/amd64/debian-wheezy/Dockerfile
@@ -12,7 +12,7 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list.d
 RUN apt-get update && apt-get install -y -t wheezy-backports btrfs-tools --no-install-recommends && rm -rf /var/lib/apt/lists/*
 RUN apt-get update && apt-get install -y apparmor bash-completion  build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev  pkg-config vim-common --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/components/engine/contrib/builder/deb/amd64/ubuntu-trusty/Dockerfile
+++ b/components/engine/contrib/builder/deb/amd64/ubuntu-trusty/Dockerfile
@@ -6,7 +6,7 @@ FROM ubuntu:trusty
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev  pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/components/engine/contrib/builder/deb/amd64/ubuntu-xenial/Dockerfile
+++ b/components/engine/contrib/builder/deb/amd64/ubuntu-xenial/Dockerfile
@@ -6,7 +6,7 @@ FROM ubuntu:xenial
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/components/engine/contrib/builder/deb/amd64/ubuntu-yakkety/Dockerfile
+++ b/components/engine/contrib/builder/deb/amd64/ubuntu-yakkety/Dockerfile
@@ -6,7 +6,7 @@ FROM ubuntu:yakkety
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/components/engine/contrib/builder/deb/amd64/ubuntu-zesty/Dockerfile
+++ b/components/engine/contrib/builder/deb/amd64/ubuntu-zesty/Dockerfile
@@ -6,7 +6,7 @@ FROM ubuntu:zesty
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/components/engine/contrib/builder/deb/armhf/debian-jessie/Dockerfile
+++ b/components/engine/contrib/builder/deb/armhf/debian-jessie/Dockerfile
@@ -10,7 +10,7 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev  pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/components/engine/contrib/builder/deb/armhf/raspbian-jessie/Dockerfile
+++ b/components/engine/contrib/builder/deb/armhf/raspbian-jessie/Dockerfile
@@ -10,7 +10,7 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev  pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 # GOARM is the ARM architecture version which is unrelated to the above Golang version
 ENV GOARM 6
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local

--- a/components/engine/contrib/builder/deb/armhf/ubuntu-trusty/Dockerfile
+++ b/components/engine/contrib/builder/deb/armhf/ubuntu-trusty/Dockerfile
@@ -6,7 +6,7 @@ FROM armhf/ubuntu:trusty
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev  pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/components/engine/contrib/builder/deb/armhf/ubuntu-xenial/Dockerfile
+++ b/components/engine/contrib/builder/deb/armhf/ubuntu-xenial/Dockerfile
@@ -6,7 +6,7 @@ FROM armhf/ubuntu:xenial
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/components/engine/contrib/builder/deb/armhf/ubuntu-yakkety/Dockerfile
+++ b/components/engine/contrib/builder/deb/armhf/ubuntu-yakkety/Dockerfile
@@ -6,7 +6,7 @@ FROM armhf/ubuntu:yakkety
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/components/engine/contrib/builder/deb/ppc64le/ubuntu-trusty/Dockerfile
+++ b/components/engine/contrib/builder/deb/ppc64le/ubuntu-trusty/Dockerfile
@@ -6,7 +6,7 @@ FROM ppc64le/ubuntu:trusty
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/components/engine/contrib/builder/deb/ppc64le/ubuntu-xenial/Dockerfile
+++ b/components/engine/contrib/builder/deb/ppc64le/ubuntu-xenial/Dockerfile
@@ -6,7 +6,7 @@ FROM ppc64le/ubuntu:xenial
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev pkg-config vim-common libseccomp-dev libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/components/engine/contrib/builder/deb/ppc64le/ubuntu-yakkety/Dockerfile
+++ b/components/engine/contrib/builder/deb/ppc64le/ubuntu-yakkety/Dockerfile
@@ -6,7 +6,7 @@ FROM ppc64le/ubuntu:yakkety
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev pkg-config vim-common libseccomp-dev libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/components/engine/contrib/builder/deb/s390x/ubuntu-xenial/Dockerfile
+++ b/components/engine/contrib/builder/deb/s390x/ubuntu-xenial/Dockerfile
@@ -6,7 +6,7 @@ FROM s390x/ubuntu:xenial
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libseccomp-dev pkg-config libsystemd-dev vim-common --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-s390x.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/components/engine/contrib/builder/deb/s390x/ubuntu-yakkety/Dockerfile
+++ b/components/engine/contrib/builder/deb/s390x/ubuntu-yakkety/Dockerfile
@@ -6,7 +6,7 @@ FROM s390x/ubuntu:yakkety
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libseccomp-dev pkg-config libsystemd-dev vim-common --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-s390x.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/components/engine/contrib/builder/rpm/amd64/amazonlinux-latest/Dockerfile
+++ b/components/engine/contrib/builder/rpm/amd64/amazonlinux-latest/Dockerfile
@@ -7,7 +7,7 @@ FROM amazonlinux:latest
 RUN yum groupinstall -y "Development Tools"
 RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel pkgconfig selinux-policy selinux-policy-devel  tar git cmake vim-common
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/components/engine/contrib/builder/rpm/amd64/centos-7/Dockerfile
+++ b/components/engine/contrib/builder/rpm/amd64/centos-7/Dockerfile
@@ -8,7 +8,7 @@ RUN yum groupinstall -y "Development Tools"
 RUN yum -y swap -- remove systemd-container systemd-container-libs -- install systemd systemd-libs
 RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel pkgconfig selinux-policy selinux-policy-devel systemd-devel tar git cmake vim-common
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/components/engine/contrib/builder/rpm/amd64/fedora-24/Dockerfile
+++ b/components/engine/contrib/builder/rpm/amd64/fedora-24/Dockerfile
@@ -8,7 +8,7 @@ RUN dnf -y upgrade
 RUN dnf install -y @development-tools fedora-packager
 RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel pkgconfig selinux-policy selinux-policy-devel systemd-devel tar git cmake vim-common
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/components/engine/contrib/builder/rpm/amd64/fedora-25/Dockerfile
+++ b/components/engine/contrib/builder/rpm/amd64/fedora-25/Dockerfile
@@ -8,7 +8,7 @@ RUN dnf -y upgrade
 RUN dnf install -y @development-tools fedora-packager
 RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel pkgconfig selinux-policy selinux-policy-devel systemd-devel tar git cmake vim-common
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/components/engine/contrib/builder/rpm/amd64/opensuse-13.2/Dockerfile
+++ b/components/engine/contrib/builder/rpm/amd64/opensuse-13.2/Dockerfile
@@ -7,7 +7,7 @@ FROM opensuse:13.2
 RUN zypper --non-interactive install ca-certificates* curl gzip rpm-build
 RUN zypper --non-interactive install libbtrfs-devel device-mapper-devel glibc-static  libselinux-devel pkg-config selinux-policy selinux-policy-devel systemd-devel tar git cmake vim systemd-rpm-macros
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/components/engine/contrib/builder/rpm/amd64/oraclelinux-6/Dockerfile
+++ b/components/engine/contrib/builder/rpm/amd64/oraclelinux-6/Dockerfile
@@ -10,7 +10,7 @@ RUN yum install -y kernel-uek-devel-4.1.12-32.el6uek
 RUN yum groupinstall -y "Development Tools"
 RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static  libselinux-devel pkgconfig selinux-policy selinux-policy-devel  tar git cmake vim-common
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/components/engine/contrib/builder/rpm/amd64/oraclelinux-7/Dockerfile
+++ b/components/engine/contrib/builder/rpm/amd64/oraclelinux-7/Dockerfile
@@ -7,7 +7,7 @@ FROM oraclelinux:7
 RUN yum groupinstall -y "Development Tools"
 RUN yum install -y --enablerepo=ol7_optional_latest btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel pkgconfig selinux-policy selinux-policy-devel systemd-devel tar git cmake vim-common
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/components/engine/contrib/builder/rpm/amd64/photon-1.0/Dockerfile
+++ b/components/engine/contrib/builder/rpm/amd64/photon-1.0/Dockerfile
@@ -7,7 +7,7 @@ FROM photon:1.0
 RUN tdnf install -y wget curl ca-certificates gzip make rpm-build sed gcc linux-api-headers glibc-devel binutils libseccomp elfutils
 RUN tdnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel pkg-config selinux-policy selinux-policy-devel systemd-devel tar git cmake vim-common
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/components/engine/contrib/builder/rpm/armhf/centos-7/Dockerfile
+++ b/components/engine/contrib/builder/rpm/armhf/centos-7/Dockerfile
@@ -9,7 +9,7 @@ RUN yum groupinstall --skip-broken -y "Development Tools"
 RUN yum -y swap -- remove systemd-container systemd-container-libs -- install systemd systemd-libs
 RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel pkgconfig selinux-policy selinux-policy-devel sqlite-devel systemd-devel tar git cmake vim-common
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/components/engine/contrib/builder/rpm/ppc64le/centos-7/Dockerfile
+++ b/components/engine/contrib/builder/rpm/ppc64le/centos-7/Dockerfile
@@ -8,7 +8,7 @@ RUN yum groupinstall -y "Development Tools"
 RUN yum -y swap -- remove systemd-container systemd-container-libs -- install systemd systemd-libs
 RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel pkgconfig selinux-policy selinux-policy-devel sqlite-devel systemd-devel tar git cmake vim-common
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/components/engine/contrib/builder/rpm/ppc64le/fedora-24/Dockerfile
+++ b/components/engine/contrib/builder/rpm/ppc64le/fedora-24/Dockerfile
@@ -8,7 +8,7 @@ RUN dnf -y upgrade
 RUN dnf install -y @development-tools fedora-packager
 RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel pkgconfig selinux-policy selinux-policy-devel sqlite-devel systemd-devel tar git cmake vim-common
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/components/engine/contrib/builder/rpm/ppc64le/opensuse-42.1/Dockerfile
+++ b/components/engine/contrib/builder/rpm/ppc64le/opensuse-42.1/Dockerfile
@@ -9,7 +9,7 @@ RUN zypper addrepo -n ppc64le-updates -f https://download.opensuse.org/ports/upd
 RUN zypper --non-interactive install ca-certificates* curl gzip rpm-build
 RUN zypper --non-interactive install libbtrfs-devel device-mapper-devel glibc-static  libselinux-devel pkg-config selinux-policy selinux-policy-devel sqlite-devel systemd-devel tar git cmake vim
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/components/engine/contrib/builder/rpm/s390x/clefos-base-s390x-7/Dockerfile
+++ b/components/engine/contrib/builder/rpm/s390x/clefos-base-s390x-7/Dockerfile
@@ -8,7 +8,7 @@ FROM sinenomine/clefos-base-s390x
 RUN touch /var/lib/rpm/* && yum groupinstall -y "Development Tools"
 RUN touch /var/lib/rpm/* && yum install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel pkgconfig selinux-policy selinux-policy-devel sqlite-devel systemd-devel tar git cmake vim-common
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-s390x.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/components/engine/contrib/builder/rpm/s390x/opensuse-tumbleweed-1/Dockerfile
+++ b/components/engine/contrib/builder/rpm/s390x/opensuse-tumbleweed-1/Dockerfile
@@ -9,7 +9,7 @@ RUN zypper ar https://download.opensuse.org/ports/zsystems/tumbleweed/repo/oss/ 
 RUN zypper --non-interactive install ca-certificates* curl gzip rpm-build
 RUN zypper --non-interactive install libbtrfs-devel device-mapper-devel glibc-static  libselinux-devel pkg-config selinux-policy selinux-policy-devel sqlite-devel systemd-devel tar git cmake vim systemd-rpm-macros
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-s390x.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/components/packaging/deb/Makefile
+++ b/components/packaging/deb/Makefile
@@ -21,7 +21,7 @@ clean: ## remove build artifacts
 deb: ubuntu debian raspbian ## build all deb packages
 
 .PHONY: ubuntu
-ubuntu: ubuntu-xenial ubuntu-trusty ## build all ubuntu deb packages
+ubuntu: ubuntu-bionic ubuntu-artful ubuntu-xenial ubuntu-trusty ## build all ubuntu deb packages
 
 .PHONY: debian
 debian: debian-stretch debian-wheezy debian-jessie ## build all debian deb packages
@@ -69,6 +69,12 @@ ubuntu-artful: ## build ubuntu artful deb packages
 		-v $(CLI_DIR):/cli \
 		-v $(CURDIR)/systemd:/root/build-deb/systemd \
 		debbuild-$@/$(ARCH)
+	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
+
+.PHONY: ubuntu-bionic
+ubuntu-bionic: ## build ubuntu bionic deb packages
+	$(BUILD)
+	$(RUN)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
 
 .PHONY: debian-buster

--- a/components/packaging/deb/debian-buster/Dockerfile.armv7l
+++ b/components/packaging/deb/debian-buster/Dockerfile.armv7l
@@ -6,7 +6,7 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/components/packaging/deb/debian-buster/Dockerfile.x86_64
+++ b/components/packaging/deb/debian-buster/Dockerfile.x86_64
@@ -6,7 +6,7 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/components/packaging/deb/debian-jessie/Dockerfile.aarch64
+++ b/components/packaging/deb/debian-jessie/Dockerfile.aarch64
@@ -6,7 +6,7 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev libudev-dev gnupg dirmngr --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/components/packaging/deb/debian-jessie/Dockerfile.armv7l
+++ b/components/packaging/deb/debian-jessie/Dockerfile.armv7l
@@ -6,7 +6,7 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libudev-dev pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/components/packaging/deb/debian-jessie/Dockerfile.x86_64
+++ b/components/packaging/deb/debian-jessie/Dockerfile.x86_64
@@ -6,7 +6,7 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libudev-dev pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/components/packaging/deb/debian-stretch/Dockerfile.aarch64
+++ b/components/packaging/deb/debian-stretch/Dockerfile.aarch64
@@ -6,7 +6,7 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev gnupg dirmngr --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/components/packaging/deb/debian-stretch/Dockerfile.armv7l
+++ b/components/packaging/deb/debian-stretch/Dockerfile.armv7l
@@ -6,7 +6,7 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/components/packaging/deb/debian-stretch/Dockerfile.x86_64
+++ b/components/packaging/deb/debian-stretch/Dockerfile.x86_64
@@ -6,7 +6,7 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/components/packaging/deb/debian-wheezy/Dockerfile.x86_64
+++ b/components/packaging/deb/debian-wheezy/Dockerfile.x86_64
@@ -8,7 +8,7 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list.d
 RUN apt-get update && apt-get install -y -t wheezy-backports btrfs-tools --no-install-recommends && rm -rf /var/lib/apt/lists/*
 RUN apt-get update && apt-get install -y apparmor bash-completion  build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libudev-dev pkg-config vim-common --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/components/packaging/deb/raspbian-jessie/Dockerfile.armv7l
+++ b/components/packaging/deb/raspbian-jessie/Dockerfile.armv7l
@@ -6,7 +6,7 @@ RUN sed -ri "s/archive.raspbian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libudev-dev pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 ENV GOARM 6
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go

--- a/components/packaging/deb/raspbian-stretch/Dockerfile.armv7l
+++ b/components/packaging/deb/raspbian-stretch/Dockerfile.armv7l
@@ -6,7 +6,7 @@ RUN sed -ri "s/archive.raspbian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 ENV GOARM 6
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go

--- a/components/packaging/deb/ubuntu-artful/Dockerfile.armv7l
+++ b/components/packaging/deb/ubuntu-artful/Dockerfile.armv7l
@@ -2,7 +2,7 @@ FROM arm32v7/ubuntu:artful
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/components/packaging/deb/ubuntu-artful/Dockerfile.ppc64le
+++ b/components/packaging/deb/ubuntu-artful/Dockerfile.ppc64le
@@ -2,7 +2,7 @@ FROM ppc64le/ubuntu:artful
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev pkg-config vim-common libseccomp-dev libsystemd-dev libltdl-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:/$GOPATH/bin

--- a/components/packaging/deb/ubuntu-artful/Dockerfile.s390x
+++ b/components/packaging/deb/ubuntu-artful/Dockerfile.s390x
@@ -2,7 +2,7 @@ FROM s390x/ubuntu:artful
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-s390x.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/components/packaging/deb/ubuntu-artful/Dockerfile.x86_64
+++ b/components/packaging/deb/ubuntu-artful/Dockerfile.x86_64
@@ -2,7 +2,7 @@ FROM ubuntu:artful
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/components/packaging/deb/ubuntu-bionic/Dockerfile.aarch64
+++ b/components/packaging/deb/ubuntu-bionic/Dockerfile.aarch64
@@ -2,7 +2,7 @@ FROM ubuntu:bionic
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go

--- a/components/packaging/deb/ubuntu-bionic/Dockerfile.aarch64
+++ b/components/packaging/deb/ubuntu-bionic/Dockerfile.aarch64
@@ -1,0 +1,29 @@
+FROM ubuntu:bionic
+
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+ENV GO_VERSION 1.9.4
+
+RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV DOCKER_BUILDTAGS apparmor seccomp selinux
+ENV RUNC_BUILDTAGS apparmor seccomp selinux
+
+COPY common/ /root/build-deb/debian
+COPY build-deb /root/build-deb/build-deb
+
+RUN mkdir -p /go/src/github.com/docker && \
+	mkdir -p /go/src/github.com/opencontainers && \
+	ln -snf /engine /root/build-deb/engine && \
+	ln -snf /cli /root/build-deb/cli && \
+	ln -snf /root/build-deb/engine /go/src/github.com/docker/docker && \
+	ln -snf /root/build-deb/cli /go/src/github.com/docker/cli
+
+
+ENV DISTRO ubuntu
+ENV SUITE bionic
+
+WORKDIR /root/build-deb
+
+ENTRYPOINT ["/root/build-deb/build-deb"]

--- a/components/packaging/deb/ubuntu-bionic/Dockerfile.armv7l
+++ b/components/packaging/deb/ubuntu-bionic/Dockerfile.armv7l
@@ -2,7 +2,7 @@ FROM ubuntu:bionic
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/components/packaging/deb/ubuntu-bionic/Dockerfile.armv7l
+++ b/components/packaging/deb/ubuntu-bionic/Dockerfile.armv7l
@@ -1,0 +1,28 @@
+FROM ubuntu:bionic
+
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+ENV GO_VERSION 1.9.4
+RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
+ENV RUNC_BUILDTAGS apparmor seccomp selinux
+
+COPY common/ /root/build-deb/debian
+COPY build-deb /root/build-deb/build-deb
+
+RUN mkdir -p /go/src/github.com/docker && \
+	mkdir -p /go/src/github.com/opencontainers && \
+	ln -snf /engine /root/build-deb/engine && \
+	ln -snf /cli /root/build-deb/cli && \
+	ln -snf /root/build-deb/engine /go/src/github.com/docker/docker && \
+	ln -snf /root/build-deb/cli /go/src/github.com/docker/cli
+
+
+ENV DISTRO ubuntu
+ENV SUITE bionic
+
+WORKDIR /root/build-deb
+
+ENTRYPOINT ["/root/build-deb/build-deb"]

--- a/components/packaging/deb/ubuntu-bionic/Dockerfile.ppc64le
+++ b/components/packaging/deb/ubuntu-bionic/Dockerfile.ppc64le
@@ -2,7 +2,7 @@ FROM ubuntu:bionic
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev pkg-config vim-common libseccomp-dev libsystemd-dev libltdl-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:/$GOPATH/bin

--- a/components/packaging/deb/ubuntu-bionic/Dockerfile.ppc64le
+++ b/components/packaging/deb/ubuntu-bionic/Dockerfile.ppc64le
@@ -1,0 +1,28 @@
+FROM ubuntu:bionic
+
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev pkg-config vim-common libseccomp-dev libsystemd-dev libltdl-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+ENV GO_VERSION 1.9.4
+RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" | tar xzC /usr/local
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:/$GOPATH/bin
+ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
+ENV RUNC_BUILDTAGS apparmor seccomp selinux
+
+COPY common/ /root/build-deb/debian
+COPY build-deb /root/build-deb/build-deb
+
+RUN mkdir -p /go/src/github.com/docker && \
+	mkdir -p /go/src/github.com/opencontainers && \
+	ln -snf /engine /root/build-deb/engine && \
+	ln -snf /cli /root/build-deb/cli && \
+	ln -snf /root/build-deb/engine /go/src/github.com/docker/docker && \
+	ln -snf /root/build-deb/cli /go/src/github.com/docker/cli
+
+
+ENV DISTRO ubuntu
+ENV SUITE bionic
+
+WORKDIR /root/build-deb
+
+ENTRYPOINT ["/root/build-deb/build-deb"]

--- a/components/packaging/deb/ubuntu-bionic/Dockerfile.s390x
+++ b/components/packaging/deb/ubuntu-bionic/Dockerfile.s390x
@@ -1,0 +1,28 @@
+FROM ubuntu:bionic
+
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+ENV GO_VERSION 1.9.4
+RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-s390x.tar.gz" | tar xzC /usr/local
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
+ENV RUNC_BUILDTAGS apparmor seccomp selinux
+
+COPY common/ /root/build-deb/debian
+COPY build-deb /root/build-deb/build-deb
+
+RUN mkdir -p /go/src/github.com/docker && \
+	mkdir -p /go/src/github.com/opencontainers && \
+	ln -snf /engine /root/build-deb/engine && \
+	ln -snf /cli /root/build-deb/cli && \
+	ln -snf /root/build-deb/engine /go/src/github.com/docker/docker && \
+	ln -snf /root/build-deb/cli /go/src/github.com/docker/cli
+
+
+ENV DISTRO ubuntu
+ENV SUITE bionic
+
+WORKDIR /root/build-deb
+
+ENTRYPOINT ["/root/build-deb/build-deb"]

--- a/components/packaging/deb/ubuntu-bionic/Dockerfile.s390x
+++ b/components/packaging/deb/ubuntu-bionic/Dockerfile.s390x
@@ -2,7 +2,7 @@ FROM ubuntu:bionic
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-s390x.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/components/packaging/deb/ubuntu-bionic/Dockerfile.x86_64
+++ b/components/packaging/deb/ubuntu-bionic/Dockerfile.x86_64
@@ -1,0 +1,28 @@
+FROM ubuntu:bionic
+
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+ENV GO_VERSION 1.9.4
+RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
+ENV RUNC_BUILDTAGS apparmor seccomp selinux
+
+COPY common/ /root/build-deb/debian
+COPY build-deb /root/build-deb/build-deb
+
+RUN mkdir -p /go/src/github.com/docker && \
+	mkdir -p /go/src/github.com/opencontainers && \
+	ln -snf /engine /root/build-deb/engine && \
+	ln -snf /cli /root/build-deb/cli && \
+	ln -snf /root/build-deb/engine /go/src/github.com/docker/docker && \
+	ln -snf /root/build-deb/cli /go/src/github.com/docker/cli
+
+
+ENV DISTRO ubuntu
+ENV SUITE bionic
+
+WORKDIR /root/build-deb
+
+ENTRYPOINT ["/root/build-deb/build-deb"]

--- a/components/packaging/deb/ubuntu-bionic/Dockerfile.x86_64
+++ b/components/packaging/deb/ubuntu-bionic/Dockerfile.x86_64
@@ -2,7 +2,7 @@ FROM ubuntu:bionic
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/components/packaging/deb/ubuntu-trusty/Dockerfile.armv7l
+++ b/components/packaging/deb/ubuntu-trusty/Dockerfile.armv7l
@@ -4,7 +4,7 @@ FROM arm32v7/ubuntu:trusty
 RUN sed -i 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|' /etc/apt/sources.list
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev  pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/components/packaging/deb/ubuntu-trusty/Dockerfile.x86_64
+++ b/components/packaging/deb/ubuntu-trusty/Dockerfile.x86_64
@@ -2,7 +2,7 @@ FROM ubuntu:trusty
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev  pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/components/packaging/deb/ubuntu-xenial/Dockerfile.aarch64
+++ b/components/packaging/deb/ubuntu-xenial/Dockerfile.aarch64
@@ -2,7 +2,7 @@ FROM arm64v8/ubuntu:xenial
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go

--- a/components/packaging/deb/ubuntu-xenial/Dockerfile.armv7l
+++ b/components/packaging/deb/ubuntu-xenial/Dockerfile.armv7l
@@ -2,7 +2,7 @@ FROM arm32v7/ubuntu:xenial
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/components/packaging/deb/ubuntu-xenial/Dockerfile.ppc64le
+++ b/components/packaging/deb/ubuntu-xenial/Dockerfile.ppc64le
@@ -2,7 +2,7 @@ FROM ppc64le/ubuntu:xenial
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:/$GOPATH/bin

--- a/components/packaging/deb/ubuntu-xenial/Dockerfile.s390x
+++ b/components/packaging/deb/ubuntu-xenial/Dockerfile.s390x
@@ -2,7 +2,7 @@ FROM s390x/ubuntu:xenial
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-s390x.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:/$GOPATH/bin

--- a/components/packaging/deb/ubuntu-xenial/Dockerfile.x86_64
+++ b/components/packaging/deb/ubuntu-xenial/Dockerfile.x86_64
@@ -2,7 +2,7 @@ FROM ubuntu:xenial
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/components/packaging/rpm/Makefile
+++ b/components/packaging/rpm/Makefile
@@ -34,10 +34,16 @@ clean: ## remove build artifacts
 rpm: fedora centos ## build all rpm packages
 
 .PHONY: fedora
-fedora: fedora-27 fedora-26 ## build all fedora rpm packages
+fedora: fedora-28 fedora-27 fedora-26 ## build all fedora rpm packages
 
 .PHONY: centos
 centos: centos-7 ## build all centos rpm packages
+
+.PHONY: fedora-28
+fedora-28: rpmbuild/SOURCES/engine.tgz rpmbuild/SOURCES/cli.tgz ## build fedora-28 rpm packages
+	docker build -t rpmbuild-$@/$(ARCH) -f $@/Dockerfile.$(ARCH) $@
+	$(RPMBUILD) rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
+	$(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
 
 .PHONY: fedora-27
 fedora-27: rpmbuild/SOURCES/engine.tgz rpmbuild/SOURCES/cli.tgz ## build fedora-27 rpm packages

--- a/components/packaging/rpm/centos-7/Dockerfile.aarch64
+++ b/components/packaging/rpm/centos-7/Dockerfile.aarch64
@@ -17,7 +17,7 @@ RUN yum install -y \
    rpmdevtools \
    vim-common
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 ENV DISTRO centos
 ENV SUITE 7
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local

--- a/components/packaging/rpm/centos-7/Dockerfile.x86_64
+++ b/components/packaging/rpm/centos-7/Dockerfile.x86_64
@@ -17,7 +17,7 @@ RUN yum install -y \
    rpmdevtools \
    vim-common
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 ENV DISTRO centos
 ENV SUITE 7
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/components/packaging/rpm/fedora-26/Dockerfile.aarch64
+++ b/components/packaging/rpm/fedora-26/Dockerfile.aarch64
@@ -2,7 +2,7 @@ FROM arm64v8/fedora:26
 RUN dnf -y upgrade
 RUN dnf install -y @development-tools fedora-packager
 RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel systemd-devel tar git cmake vim-common
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 ENV DISTRO fedora
 ENV SUITE 26
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local

--- a/components/packaging/rpm/fedora-26/Dockerfile.x86_64
+++ b/components/packaging/rpm/fedora-26/Dockerfile.x86_64
@@ -2,7 +2,7 @@ FROM fedora:26
 RUN dnf -y upgrade
 RUN dnf install -y @development-tools fedora-packager
 RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel systemd-devel tar git cmake vim-common
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 ENV DISTRO fedora
 ENV SUITE 26
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/components/packaging/rpm/fedora-27/Dockerfile.aarch64
+++ b/components/packaging/rpm/fedora-27/Dockerfile.aarch64
@@ -2,7 +2,7 @@ FROM arm64v8/fedora:27
 RUN dnf -y upgrade
 RUN dnf install -y @development-tools fedora-packager
 RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel systemd-devel tar git cmake vim-common
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 ENV DISTRO fedora
 ENV SUITE 27
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local

--- a/components/packaging/rpm/fedora-27/Dockerfile.x86_64
+++ b/components/packaging/rpm/fedora-27/Dockerfile.x86_64
@@ -2,7 +2,7 @@ FROM fedora:27
 RUN dnf -y upgrade
 RUN dnf install -y @development-tools fedora-packager
 RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel systemd-devel tar git cmake vim-common
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 ENV DISTRO fedora
 ENV SUITE 27
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/components/packaging/rpm/fedora-28/Dockerfile.aarch64
+++ b/components/packaging/rpm/fedora-28/Dockerfile.aarch64
@@ -2,7 +2,7 @@ FROM fedora:28
 RUN dnf -y upgrade
 RUN dnf install -y @development-tools fedora-packager
 RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel systemd-devel tar git cmake vim-common
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 ENV DISTRO fedora
 ENV SUITE 28
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local

--- a/components/packaging/rpm/fedora-28/Dockerfile.aarch64
+++ b/components/packaging/rpm/fedora-28/Dockerfile.aarch64
@@ -1,0 +1,17 @@
+FROM fedora:28
+RUN dnf -y upgrade
+RUN dnf install -y @development-tools fedora-packager
+RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel systemd-devel tar git cmake vim-common
+ENV GO_VERSION 1.9.4
+ENV DISTRO fedora
+ENV SUITE 28
+RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV AUTO_GOPATH 1
+ENV DOCKER_BUILDTAGS pkcs11 seccomp selinux
+ENV RUNC_BUILDTAGS seccomp selinux
+RUN mkdir -p /go/src/github.com/docker && mkdir -p /go/src/github.com/opencontainers
+COPY docker-ce.spec /root/rpmbuild/SPECS/docker-ce.spec
+WORKDIR /root/rpmbuild
+ENTRYPOINT ["/bin/rpmbuild"]

--- a/components/packaging/rpm/fedora-28/Dockerfile.x86_64
+++ b/components/packaging/rpm/fedora-28/Dockerfile.x86_64
@@ -2,7 +2,7 @@ FROM fedora:28
 RUN dnf -y upgrade
 RUN dnf install -y @development-tools fedora-packager
 RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel systemd-devel tar git cmake vim-common
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 ENV DISTRO fedora
 ENV SUITE 28
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/components/packaging/rpm/fedora-28/Dockerfile.x86_64
+++ b/components/packaging/rpm/fedora-28/Dockerfile.x86_64
@@ -1,0 +1,17 @@
+FROM fedora:28
+RUN dnf -y upgrade
+RUN dnf install -y @development-tools fedora-packager
+RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel systemd-devel tar git cmake vim-common
+ENV GO_VERSION 1.9.4
+ENV DISTRO fedora
+ENV SUITE 28
+RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV AUTO_GOPATH 1
+ENV DOCKER_BUILDTAGS pkcs11 seccomp selinux
+ENV RUNC_BUILDTAGS seccomp selinux
+RUN mkdir -p /go/src/github.com/docker && mkdir -p /go/src/github.com/opencontainers
+COPY docker-ce.spec /root/rpmbuild/SPECS/docker-ce.spec
+WORKDIR /root/rpmbuild
+ENTRYPOINT ["/bin/rpmbuild"]

--- a/components/packaging/rpm/fedora-28/docker-ce.spec
+++ b/components/packaging/rpm/fedora-28/docker-ce.spec
@@ -1,0 +1,211 @@
+Name: docker-ce
+Version: %{_version}
+Release: %{_release}%{?dist}
+Summary: The open-source application container engine
+Group: Tools/Docker
+License: ASL 2.0
+Source0: engine.tgz
+Source1: cli.tgz
+URL: https://www.docker.com
+Vendor: Docker
+Packager: Docker <support@docker.com>
+
+# DWZ problem with multiple golang binary, see bug
+# https://bugzilla.redhat.com/show_bug.cgi?id=995136#c12
+%global _dwz_low_mem_die_limit 0
+%global is_systemd 1
+%global with_selinux 1
+%global _missing_build_ids_terminate_build 0
+
+BuildRequires: pkgconfig(systemd)
+
+# required packages on install
+Requires: /bin/sh
+Requires: container-selinux >= 2.9
+Requires: iptables
+Requires: libcgroup
+Requires: systemd-units
+Requires: tar
+Requires: xz
+Requires: pigz
+
+# Resolves: rhbz#1165615
+Requires: device-mapper-libs >= 1.02.90-1
+
+# conflicting packages
+Conflicts: docker
+Conflicts: docker-io
+Conflicts: docker-engine-cs
+Conflicts: docker-ee
+
+# Obsolete packages
+Obsoletes: docker-ce-selinux
+Obsoletes: docker-engine-selinux
+Obsoletes: docker-engine
+
+%description
+Docker is an open source project to build, ship and run any application as a
+lightweight container.
+
+Docker containers are both hardware-agnostic and platform-agnostic. This means
+they can run anywhere, from your laptop to the largest EC2 compute instance and
+everything in between - and they don't require you to use a particular
+language, framework or packaging system. That makes them great building blocks
+for deploying and scaling web apps, databases, and backend services without
+depending on a particular stack or provider.
+
+%prep
+%setup -q -c -n src -a 1
+
+%build
+export DOCKER_GITCOMMIT=%{_gitcommit}
+mkdir -p /go/src/github.com/docker
+rm -f /go/src/github.com/docker/cli
+ln -s /root/rpmbuild/BUILD/src/cli /go/src/github.com/docker/cli
+pushd /go/src/github.com/docker/cli
+make VERSION=%{_origversion} GITCOMMIT=%{_gitcommit} dynbinary manpages # cli
+popd
+pushd engine
+for component in tini "proxy dynamic" "runc all" "containerd dynamic";do
+    TMP_GOPATH="/go" hack/dockerfile/install/install.sh $component
+done
+VERSION=%{_origversion} hack/make.sh dynbinary
+popd
+mkdir -p plugin
+printf '{"edition_type":"ce","edition_name":"%s","edition_version":"%s"}\n' "${DISTRO}" "%{_version}" > plugin/.plugin-metadata
+
+%check
+cli/build/docker -v
+engine/bundles/dynbinary-daemon/dockerd -v
+
+%install
+# install binary
+install -d $RPM_BUILD_ROOT/%{_bindir}
+install -p -m 755 cli/build/docker $RPM_BUILD_ROOT/%{_bindir}/docker
+install -p -m 755 $(readlink -f engine/bundles/dynbinary-daemon/dockerd) $RPM_BUILD_ROOT/%{_bindir}/dockerd
+
+# install proxy
+install -p -m 755 /usr/local/bin/docker-proxy $RPM_BUILD_ROOT/%{_bindir}/docker-proxy
+
+# install containerd
+install -p -m 755 /usr/local/bin/docker-containerd $RPM_BUILD_ROOT/%{_bindir}/docker-containerd
+install -p -m 755 /usr/local/bin/docker-containerd-shim $RPM_BUILD_ROOT/%{_bindir}/docker-containerd-shim
+install -p -m 755 /usr/local/bin/docker-containerd-ctr $RPM_BUILD_ROOT/%{_bindir}/docker-containerd-ctr
+
+# install runc
+install -p -m 755 /usr/local/bin/docker-runc $RPM_BUILD_ROOT/%{_bindir}/docker-runc
+
+# install tini
+install -p -m 755 /usr/local/bin/docker-init $RPM_BUILD_ROOT/%{_bindir}/docker-init
+
+# install udev rules
+install -d $RPM_BUILD_ROOT/%{_sysconfdir}/udev/rules.d
+install -p -m 644 engine/contrib/udev/80-docker.rules $RPM_BUILD_ROOT/%{_sysconfdir}/udev/rules.d/80-docker.rules
+
+# add init scripts
+install -d $RPM_BUILD_ROOT/etc/sysconfig
+install -d $RPM_BUILD_ROOT/%{_initddir}
+install -d $RPM_BUILD_ROOT/%{_unitdir}
+# Fedora 25+ supports (and needs) TasksMax
+sed -i 's/^#TasksMax=/TasksMax=/' /systemd/docker.service
+install -p -m 644 /systemd/docker.service $RPM_BUILD_ROOT/%{_unitdir}/docker.service
+# add bash, zsh, and fish completions
+install -d $RPM_BUILD_ROOT/usr/share/bash-completion/completions
+install -d $RPM_BUILD_ROOT/usr/share/zsh/vendor-completions
+install -d $RPM_BUILD_ROOT/usr/share/fish/vendor_completions.d
+install -p -m 644 cli/contrib/completion/bash/docker $RPM_BUILD_ROOT/usr/share/bash-completion/completions/docker
+install -p -m 644 cli/contrib/completion/zsh/_docker $RPM_BUILD_ROOT/usr/share/zsh/vendor-completions/_docker
+install -p -m 644 cli/contrib/completion/fish/docker.fish $RPM_BUILD_ROOT/usr/share/fish/vendor_completions.d/docker.fish
+
+# install manpages
+install -d %{buildroot}%{_mandir}/man1
+install -p -m 644 cli/man/man1/*.1 $RPM_BUILD_ROOT/%{_mandir}/man1
+install -d %{buildroot}%{_mandir}/man5
+install -p -m 644 cli/man/man5/*.5 $RPM_BUILD_ROOT/%{_mandir}/man5
+install -d %{buildroot}%{_mandir}/man8
+install -p -m 644 cli/man/man8/*.8 $RPM_BUILD_ROOT/%{_mandir}/man8
+
+# add vimfiles
+install -d $RPM_BUILD_ROOT/usr/share/vim/vimfiles/doc
+install -d $RPM_BUILD_ROOT/usr/share/vim/vimfiles/ftdetect
+install -d $RPM_BUILD_ROOT/usr/share/vim/vimfiles/syntax
+install -p -m 644 engine/contrib/syntax/vim/doc/dockerfile.txt $RPM_BUILD_ROOT/usr/share/vim/vimfiles/doc/dockerfile.txt
+install -p -m 644 engine/contrib/syntax/vim/ftdetect/dockerfile.vim $RPM_BUILD_ROOT/usr/share/vim/vimfiles/ftdetect/dockerfile.vim
+install -p -m 644 engine/contrib/syntax/vim/syntax/dockerfile.vim $RPM_BUILD_ROOT/usr/share/vim/vimfiles/syntax/dockerfile.vim
+
+# add nano
+install -d $RPM_BUILD_ROOT/usr/share/nano
+install -p -m 644 engine/contrib/syntax/nano/Dockerfile.nanorc $RPM_BUILD_ROOT/usr/share/nano/Dockerfile.nanorc
+
+mkdir -p build-docs
+for engine_file in AUTHORS CHANGELOG.md CONTRIBUTING.md LICENSE MAINTAINERS NOTICE README.md; do
+    cp "engine/$engine_file" "build-docs/engine-$engine_file"
+done
+for cli_file in LICENSE MAINTAINERS NOTICE README.md; do
+    cp "cli/$cli_file" "build-docs/cli-$cli_file"
+done
+
+# list files owned by the package here
+%files
+%doc build-docs/engine-AUTHORS build-docs/engine-CHANGELOG.md build-docs/engine-CONTRIBUTING.md build-docs/engine-LICENSE build-docs/engine-MAINTAINERS build-docs/engine-NOTICE build-docs/engine-README.md
+%doc build-docs/cli-LICENSE build-docs/cli-MAINTAINERS build-docs/cli-NOTICE build-docs/cli-README.md
+/%{_bindir}/docker
+/%{_bindir}/dockerd
+/%{_bindir}/docker-containerd
+/%{_bindir}/docker-containerd-shim
+/%{_bindir}/docker-containerd-ctr
+/%{_bindir}/docker-proxy
+/%{_bindir}/docker-runc
+/%{_bindir}/docker-init
+/%{_sysconfdir}/udev/rules.d/80-docker.rules
+/%{_unitdir}/docker.service
+/usr/share/bash-completion/completions/docker
+/usr/share/zsh/vendor-completions/_docker
+/usr/share/fish/vendor_completions.d/docker.fish
+%doc
+/%{_mandir}/man1/*
+/%{_mandir}/man5/*
+/%{_mandir}/man8/*
+/usr/share/vim/vimfiles/doc/dockerfile.txt
+/usr/share/vim/vimfiles/ftdetect/dockerfile.vim
+/usr/share/vim/vimfiles/syntax/dockerfile.vim
+/usr/share/nano/Dockerfile.nanorc
+
+%pre
+if [ $1 -gt 0 ] ; then
+    # package upgrade scenario, before new files are installed
+
+    # clear any old state
+    rm -f %{_localstatedir}/lib/rpm-state/docker-is-active > /dev/null 2>&1 || :
+
+    # check if docker service is running
+    if systemctl is-active docker > /dev/null 2>&1; then
+        systemctl stop docker > /dev/null 2>&1 || :
+        touch %{_localstatedir}/lib/rpm-state/docker-is-active > /dev/null 2>&1 || :
+    fi
+fi
+
+%post
+%systemd_post docker
+if ! getent group docker > /dev/null; then
+    groupadd --system docker
+fi
+
+%preun
+%systemd_preun docker
+
+%postun
+%systemd_postun_with_restart docker
+
+%posttrans
+if [ $1 -ge 0 ] ; then
+    # package upgrade scenario, after new files are installed
+
+    # check if docker was running before upgrade
+    if [ -f %{_localstatedir}/lib/rpm-state/docker-is-active ]; then
+        systemctl start docker > /dev/null 2>&1 || :
+        rm -f %{_localstatedir}/lib/rpm-state/docker-is-active > /dev/null 2>&1 || :
+    fi
+fi
+
+%changelog


### PR DESCRIPTION
Backport for 18.03 of:

- https://github.com/docker/cli/pull/986
- https://github.com/moby/moby/pull/36779
- https://github.com/docker/docker-ce-packaging/pull/103

Also included:

- https://github.com/docker/docker-ce-packaging/pull/97 Add building code for Ubuntu Bionic (18.04) LTS
- https://github.com/docker/docker-ce-packaging/pull/98 Add packaging code for Fedora 28
- https://github.com/docker/docker-ce-packaging/pull/99 Add Ubuntu 18.04 arm64 builds


```
git checkout -b 18.03-backport-bump-golang-1.9.5 upstream/18.03
git cherry-pick -s -S -x -Xsubtree=components/cli d3b8ceb52cad0c1b16c8e04eb70da4835f81add4
git cherry-pick -s -S -x -Xsubtree=components/engine 0b6f8a7eff325a683b10d64db363da2145aa1c36
git cherry-pick -s -S -x -Xsubtree=components/packaging 460f0b5becbbc5ec2bd341df409af8f06c0a70f7
git cherry-pick -s -S -x -Xsubtree=components/packaging 00148a3c994c753a3e171b1aa2b422342e00fd16
git cherry-pick -s -S -x -Xsubtree=components/packaging aac8310bbee3c7480487a624756d25d22d53c7dd
git cherry-pick -s -S -x -Xsubtree=components/packaging c62336593118020462d65d4e9784143e07de2da7
git push -u origin 18.03-backport-bump-golang-1.9.5
```

Some conflicts in the "engine" cherry-pick because the PR to change the Dockerfile to use "multistage build" and multi-arch is not part of 18.03, so I added an extra commit to update the other Dockerfiles accordingly
