### PR TITLE
[18.03] daemon/cluster: handle partial attachment entries during configure

### DIFF
--- a/components/engine/daemon/cluster/executor/container/executor.go
+++ b/components/engine/daemon/cluster/executor/container/executor.go
@@ -141,13 +141,22 @@ func (e *executor) Configure(ctx context.Context, node *api.Node) error {
 	attachments := make(map[string]string)
 
 	for _, na := range node.Attachments {
+		if na == nil || na.Network == nil || len(na.Addresses) == 0 {
+			// this should not happen, but we got a panic here and don't have a
+			// good idea about what the underlying data structure looks like.
+			logrus.WithField("NetworkAttachment", fmt.Sprintf("%#v", na)).
+				Warnf("skipping nil or malformed node network attachment entry")
+			continue
+		}
+
 		if na.Network.Spec.Ingress {
 			ingressNA = na
 		}
+
 		attachments[na.Network.ID] = na.Addresses[0]
 	}
 
-	if (ingressNA == nil) && (node.Attachment != nil) {
+	if (ingressNA == nil) && (node.Attachment != nil) && (len(node.Attachment.Addresses) > 0) {
 		ingressNA = node.Attachment
 		attachments[ingressNA.Network.ID] = ingressNA.Addresses[0]
 	}


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/36769 for 18.03


```
git checkout -b 18.03-backport-defensive-attachment-processing upstream/18.03
git cherry-pick -s -S -x -Xsubtree=components/engine 454128c6e82cded211c1412e3eb350b1f7533ee2
git push -u origin 18.03-backport-defensive-attachment-processing
```

no conflicts



We have seen a panic when re-joining a node to a swarm cluster. The
cause of the issue is unknown, so we just need to add a test for nil
objects and log when we get the condition. Hopefully this can prevent
the crash and we can recover the config at a later time.

Signed-off-by: Stephen J Day <stephen.day@docker.com>
(cherry picked from commit 454128c6e82cded211c1412e3eb350b1f7533ee2)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

Please do not send pull requests to this docker/docker-ce repository.

We do, however, take contributions gladly.

See https://github.com/docker/docker-ce/blob/master/CONTRIBUTING.md

Thanks!
