### PR TITLE
[18.03] Fix stack deploy re-deploying service after --force

### DIFF
--- a/components/cli/cli/command/stack/swarm/deploy_composefile.go
+++ b/components/cli/cli/command/stack/swarm/deploy_composefile.go
@@ -249,6 +249,12 @@ func deployServices(
 				// service update.
 				serviceSpec.TaskTemplate.ContainerSpec.Image = service.Spec.TaskTemplate.ContainerSpec.Image
 			}
+
+			// Stack deploy does not have a `--force` option. Preserve existing ForceUpdate
+			// value so that tasks are not re-deployed if not updated.
+			// TODO move this to API client?
+			serviceSpec.TaskTemplate.ForceUpdate = service.Spec.TaskTemplate.ForceUpdate
+
 			response, err := apiClient.ServiceUpdate(
 				ctx,
 				service.ID,


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/963 for 18.03

```
git checkout -b 18.03-backport-fix-stack-deploy-after-force upstream/18.03
git cherry-pick -s -S -x -Xsubtree=components/cli 76439457d2607806d07b1627fd0e25736ce14fae
git push -u origin 18.03-backport-fix-stack-deploy-after-force
```

no conflicts



When updating a service with the `--force` option, the `ForceUpdate`
property of the taskspec is incremented.

Stack deploy did not take this into account, and reset this
field to its default value (0), causing the service to be
re-deployed.

This patch copies the existing value before updating the service.
