### PR TITLE
[18.03] Increase raft ElectionTick to 10xHeartbeatTick

### DIFF
--- a/components/engine/daemon/cluster/noderunner.go
+++ b/components/engine/daemon/cluster/noderunner.go
@@ -122,10 +122,13 @@ func (n *nodeRunner) start(conf nodeStartConfig) error {
 		JoinToken:          conf.joinToken,
 		Executor:           container.NewExecutor(n.cluster.config.Backend, n.cluster.config.PluginBackend),
 		HeartbeatTick:      1,
-		ElectionTick:       3,
-		UnlockKey:          conf.lockKey,
-		AutoLockManagers:   conf.autolock,
-		PluginGetter:       n.cluster.config.Backend.PluginGetter(),
+		// Recommended value in etcd/raft is 10 x (HeartbeatTick).
+		// Lower values were seen to have caused instability because of
+		// frequent leader elections when running on flakey networks.
+		ElectionTick:     10,
+		UnlockKey:        conf.lockKey,
+		AutoLockManagers: conf.autolock,
+		PluginGetter:     n.cluster.config.Backend.PluginGetter(),
 	}
 	if conf.availability != "" {
 		avail, ok := swarmapi.NodeSpec_Availability_value[strings.ToUpper(string(conf.availability))]


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/36672 for 18.03


```
git checkout -b 18.03-backport-election upstream/18.03
git cherry-pick -s -S -x -Xsubtree=components/engine 6abee2008b314a65553202b15d9a333d171e3433
git push -u origin 18.03-backport-election
```

cherry-pick wasn't clean due to https://github.com/moby/moby/pull/36240 not being in 18.03, but trivial to resolve

```patch
diff --cc components/engine/daemon/cluster/noderunner.go
index f832aca145,989551a6ca..0000000000
--- a/components/engine/daemon/cluster/noderunner.go
+++ b/components/engine/daemon/cluster/noderunner.go
@@@ -120,12 -120,18 +120,27 @@@ func (n *nodeRunner) start(conf nodeSta
                JoinAddr:           joinAddr,
                StateDir:           n.cluster.root,
                JoinToken:          conf.joinToken,
++<<<<<<< HEAD
 +              Executor:           container.NewExecutor(n.cluster.config.Backend, n.cluster.config.PluginBackend),
 +              HeartbeatTick:      1,
 +              ElectionTick:       3,
 +              UnlockKey:          conf.lockKey,
 +              AutoLockManagers:   conf.autolock,
 +              PluginGetter:       n.cluster.config.Backend.PluginGetter(),
++=======
+               Executor: container.NewExecutor(
+                       n.cluster.config.Backend,
+                       n.cluster.config.PluginBackend,
+                       n.cluster.config.ImageBackend),
+               HeartbeatTick: 1,
+               // Recommended value in etcd/raft is 10 x (HeartbeatTick).
+               // Lower values were seen to have caused instability because of
+               // frequent leader elections when running on flakey networks.
+               ElectionTick:     10,
+               UnlockKey:        conf.lockKey,
+               AutoLockManagers: conf.autolock,
+               PluginGetter:     n.cluster.config.Backend.PluginGetter(),
++>>>>>>> 6abee2008b... Increase raft ElectionTick to 10xHeartbeatTick
        }
        if conf.availability != "" {
                avail, ok := swarmapi.NodeSpec_Availability_value[strings.ToUpper(string(conf.availability))]
```