### PR TITLE
[18.03] backport docs and completion fixes

### DIFF
--- a/components/cli/contrib/completion/bash/docker
+++ b/components/cli/contrib/completion/bash/docker
@@ -1220,14 +1220,18 @@ _docker_config_create() {
 		--label|-l)
 			return
 			;;
+		--template-driver)
+			COMPREPLY=( $( compgen -W "golang" -- "$cur" ) )
+			return
+			;;
 	esac
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--help --label -l" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--help --label -l --template-driver" -- "$cur" ) )
 			;;
 		*)
-			local counter=$(__docker_pos_first_nonflag '--label|-l')
+			local counter=$(__docker_pos_first_nonflag '--label|-l|--template-driver')
 			if [ "$cword" -eq "$((counter + 1))" ]; then
 				_filedir
 			fi
@@ -4238,14 +4242,18 @@ _docker_secret_create() {
 		--driver|-d|--label|-l)
 			return
 			;;
+		--template-driver)
+			COMPREPLY=( $( compgen -W "golang" -- "$cur" ) )
+			return
+			;;
 	esac
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--driver -d --help --label -l" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--driver -d --help --label -l --template-driver" -- "$cur" ) )
 			;;
 		*)
-			local counter=$(__docker_pos_first_nonflag '--driver|-d|--label|-l')
+			local counter=$(__docker_pos_first_nonflag '--driver|-d|--label|-l|--template-driver')
 			if [ "$cword" -eq "$((counter + 1))" ]; then
 				_filedir
 			fi

--- a/components/cli/docs/extend/index.md
+++ b/components/cli/docs/extend/index.md
@@ -218,20 +218,22 @@ plugins. This is specifically useful to collect plugin logs if they are
 redirected to a file.
 
 ```bash
-$ docker-runc list
-ID                                                                 PID         STATUS      BUNDLE                                                                                       CREATED
-f52a3df433b9aceee436eaada0752f5797aab1de47e5485f1690a073b860ff62   2679        running     /run/docker/libcontainerd/f52a3df433b9aceee436eaada0752f5797aab1de47e5485f1690a073b860ff62	2017-02-06T21:53:03.031537592Z
-r
+$ sudo docker-runc --root /var/run/docker/plugins/runtime-root/moby-plugins list
+
+ID                                                                 PID         STATUS      BUNDLE                                                                                                                                       CREATED                          OWNER
+93f1e7dbfe11c938782c2993628c895cf28e2274072c4a346a6002446c949b25   15806       running     /run/docker/containerd/daemon/io.containerd.runtime.v1.linux/moby-plugins/93f1e7dbfe11c938782c2993628c895cf28e2274072c4a346a6002446c949b25   2018-02-08T21:40:08.621358213Z   root
+9b4606d84e06b56df84fadf054a21374b247941c94ce405b0a261499d689d9c9   14992       running     /run/docker/containerd/daemon/io.containerd.runtime.v1.linux/moby-plugins/9b4606d84e06b56df84fadf054a21374b247941c94ce405b0a261499d689d9c9   2018-02-08T21:35:12.321325872Z   root
+c5bb4b90941efcaccca999439ed06d6a6affdde7081bb34dc84126b57b3e793d   14984       running     /run/docker/containerd/daemon/io.containerd.runtime.v1.linux/moby-plugins/c5bb4b90941efcaccca999439ed06d6a6affdde7081bb34dc84126b57b3e793d   2018-02-08T21:35:12.321288966Z   root
 ```
 
 ```bash
-$ docker-runc exec f52a3df433b9aceee436eaada0752f5797aab1de47e5485f1690a073b860ff62 cat /var/log/plugin.log
+$ sudo docker-runc --root /var/run/docker/plugins/runtime-root/moby-plugins exec 93f1e7dbfe11c938782c2993628c895cf28e2274072c4a346a6002446c949b25 cat /var/log/plugin.log
 ```
 
 If the plugin has a built-in shell, then exec into the plugin can be done as
 follows:
 ```bash
-$ docker-runc exec -t f52a3df433b9aceee436eaada0752f5797aab1de47e5485f1690a073b860ff62 sh
+$ sudo docker-runc --root /var/run/docker/plugins/runtime-root/moby-plugins exec -t 93f1e7dbfe11c938782c2993628c895cf28e2274072c4a346a6002446c949b25 sh
 ```
 
 #### Using curl to debug plugin socket issues.

--- a/components/cli/docs/reference/commandline/build.md
+++ b/components/cli/docs/reference/commandline/build.md
@@ -411,13 +411,13 @@ files. The `ARG` instruction lets Dockerfile authors define values that users
 can set at build-time using the  `--build-arg` flag:
 
 ```bash
-$ docker build --build-arg HTTP_PROXY=http://10.20.30.2:1234 .
+$ docker build --build-arg HTTP_PROXY=http://10.20.30.2:1234 --build-arg FTP_PROXY=http://40.50.60.5:4567 .
 ```
 
 This flag allows you to pass the build-time variables that are
 accessed like regular environment variables in the `RUN` instruction of the
 Dockerfile. Also, these values don't persist in the intermediate or final images
-like `ENV` values do.
+like `ENV` values do.   You must add `--build-arg` for each build argument.  
 
 Using this flag will not alter the output you see when the `ARG` lines from the
 Dockerfile are echoed during the build process.

--- a/components/cli/docs/reference/commandline/build.md
+++ b/components/cli/docs/reference/commandline/build.md
@@ -425,6 +425,18 @@ Dockerfile are echoed during the build process.
 For detailed information on using `ARG` and `ENV` instructions, see the
 [Dockerfile reference](../builder.md).
 
+You may also use the `--build-arg` flag without a value, in which case the value
+from the local environment will be propagated into the Docker container being
+built:
+
+```bash
+$ export HTTP_PROXY=http://10.20.30.2:1234
+$ docker build --build-arg HTTP_PROXY .
+```
+
+This is similar to how `docker run -e` works. Refer to the [`docker run` documentation](https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file)
+for more information.
+
 ### Optional security options (--security-opt)
 
 This flag is only supported on a daemon running on Windows, and only supports
@@ -504,7 +516,7 @@ section in the userguide for more information.
 
 The `--squash` option has a number of known limitations:
 
-- When squashing layers, the resulting image cannot take advantage of layer 
+- When squashing layers, the resulting image cannot take advantage of layer
   sharing with other images, and may use significantly more space. Sharing the
   base image is still supported.
 - When using this option you may see significantly more space used due to
@@ -581,7 +593,7 @@ $ docker build --squash -t test .
 If everything is right, the history will look like this:
 
 ```bash
-$ docker history test 
+$ docker history test
 
 IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
 4e10cb5b4cac        3 seconds ago                                                       12 B                merge sha256:88a7b0112a41826885df0e7072698006ee8f621c6ab99fca7fe9151d7b599702 to sha256:47bcc53f74dc94b1920f0b34f6036096526296767650f223433fe65c35f149eb

--- a/components/cli/docs/reference/commandline/history.md
+++ b/components/cli/docs/reference/commandline/history.md
@@ -77,17 +77,11 @@ output the data exactly as the template declares or, when using the
 `table` directive, will include column headers as well.
 
 The following example uses a template without headers and outputs the
-`ID` and `CreatedSince` entries separated by a colon for all images:
+`ID` and `CreatedSince` entries separated by a colon for the `busybox` image:
 
 ```bash
-$ docker images --format "{{.ID}}: {{.Created}} ago"
+$ docker history --format "{{.ID}}: {{.CreatedAt}}" busybox
 
-cc1b61406712: 2 weeks ago
-<missing>: 2 weeks ago
-<missing>: 2 weeks ago
-<missing>: 2 weeks ago
-<missing>: 2 weeks ago
-<missing>: 3 weeks ago
-<missing>: 3 weeks ago
-<missing>: 3 weeks ago
+f6e427c148a7: 4 weeks ago
+<missing>: 4 weeks ago
 ```

--- a/components/cli/docs/reference/commandline/load.md
+++ b/components/cli/docs/reference/commandline/load.md
@@ -35,7 +35,7 @@ bzip2, or xz) from a file or STDIN. It restores both images and tags.
 ## Examples
 
 ```bash
-$ docker docker image ls
+$ docker image ls
 
 REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
 

--- a/components/cli/docs/reference/commandline/run.md
+++ b/components/cli/docs/reference/commandline/run.md
@@ -592,7 +592,7 @@ Docker supports the following restart policies:
 |:---------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `no`                       | Do not automatically restart the container when it exits. This is the default.                                                                                                                                                                                   |
 | `on-failure[:max-retries]` | Restart only if the container exits with a non-zero exit status. Optionally, limit the number of restart retries the Docker daemon attempts.                                                                                                                     |
-| `unless-stopped`           | Restart the container unless it is explicitly stopped or Docker itself is stopped or restarted. |
+| `unless-stopped`           | Restart the container unless it is explicitly stopped or Docker itself is stopped or restarted.                                                                                                                                                                  |
 | `always`                   | Always restart the container regardless of the exit status. When you specify always, the Docker daemon will try to restart the container indefinitely. The container will also always start on daemon startup, regardless of the current state of the container. |
 
 ```bash
@@ -603,7 +603,7 @@ This will run the `redis` container with a restart policy of **always**
 so that if the container exits, Docker will restart it.
 
 More detailed information on restart policies can be found in the
-[Restart Policies (--restart)](../run.md#restart-policies-restart)
+[Restart Policies (--restart)](../run.md#restart-policies---restart)
 section of the Docker run reference page.
 
 ### Add entries to container hosts file (--add-host)

--- a/components/cli/docs/reference/commandline/secret_create.md
+++ b/components/cli/docs/reference/commandline/secret_create.md
@@ -27,7 +27,7 @@ Options:
 
 ## Description
 
-Creates a secret using standard input or from a file for the secret content. You must run this command on a manager node. 
+Creates a secret using standard input or from a file for the secret content. You must run this command on a manager node.
 
 For detailed information about using secrets, refer to [manage sensitive data with Docker secrets](https://docs.docker.com/engine/swarm/secrets/).
 
@@ -36,7 +36,7 @@ For detailed information about using secrets, refer to [manage sensitive data wi
 ### Create a secret
 
 ```bash
-$ echo <secret> | docker secret create my_secret -
+$ printf <secret> | docker secret create my_secret -
 
 onakdyv307se2tl7nl20anokv
 

--- a/components/cli/docs/reference/run.md
+++ b/components/cli/docs/reference/run.md
@@ -620,7 +620,7 @@ systems can really pile up. If instead you'd like Docker to
 **automatically clean up the container and remove the file system when
 the container exits**, you can add the `--rm` flag:
 
-    --rm=false: Automatically remove the container when it exits (incompatible with -d)
+    --rm=false: Automatically remove the container when it exits
 
 > **Note**: When you set the `--rm` flag, Docker also removes the anonymous volumes
 associated with the container when the container is removed. This is similar

--- a/components/cli/docs/reference/run.md
+++ b/components/cli/docs/reference/run.md
@@ -525,9 +525,9 @@ Docker supports the following restart policies:
     <tr>
       <td><strong>unless-stopped</strong></td>
       <td>
-        Always restart the container regardless of the exit status, but
-        do not start it on daemon startup if the container has been put
-        to a stopped state before.
+        Always restart the container regardless of the exit status,
+        including on daemon startup, except if the container was put
+        into a stopped state before the Docker daemon was stopped.
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
docs and completion cherry-picks for 18.03 of:

- https://github.com/docker/cli/pull/957 Docs touch-ups for "autoremove" and broken anchor
- https://github.com/docker/cli/pull/962 Clarify behaviour of restart policy in run ref doc
- https://github.com/docker/cli/pull/970 Clarify --build-arg documentation
- https://github.com/docker/cli/pull/979 Use printf, not echo when creating secrets
- https://github.com/docker/cli/pull/980 Fix --format example for docker history
- https://github.com/docker/cli/pull/988 Update examples to reflect docker-runc's runtime root for plugins.
- https://github.com/docker/cli/pull/999 build.md: Document --build-arg without value
- https://github.com/docker/cli/pull/1007 docs: Typofix in example "docker image ls"
- https://github.com/docker/cli/pull/1004 Add bash completion for `secret|config create --template-driver`


```
git checkout -b 18.03-backport-docs-fixes upstream/18.03
git cherry-pick -s -S -x -Xsubtree=components/cli e9ce688d6e6d990794b51fac5ed2fed619c89f4f
git cherry-pick -s -S -x -Xsubtree=components/cli 8ca237054f13c585ce5880c2c193d106ac22c9cd
git cherry-pick -s -S -x -Xsubtree=components/cli ad44e2d45e35d09890473e20f6b2ad16de98d72a
git cherry-pick -s -S -x -Xsubtree=components/cli 5238f3e93e6141b3615e7c8b38adae5ea2175385
git cherry-pick -s -S -x -Xsubtree=components/cli 2f7bf40e733e337dadc998ae99d93fe5da5e4a16
git cherry-pick -s -S -x -Xsubtree=components/cli 5fd9eab3d0cec4d1fb3d03cd9eb4c250cf2bd23a
git cherry-pick -s -S -x -Xsubtree=components/cli 82c23208eeba822473d444221399a7102479a702
git cherry-pick -s -S -x -Xsubtree=components/cli 79c489d812524ae5a0ff26c44fa4bb2e309810bb
git cherry-pick -s -S -x -Xsubtree=components/cli 43024e2d57d7bdd63c358ac65bc3c6d1e6a4d702
git push -u origin 18.03-backport-docs-fixes
```

no conflicts