### PR TITLE
[18.05] daemon.getSourceMount(): fix for / mount point

### DIFF
--- a/components/engine/daemon/oci_linux.go
+++ b/components/engine/daemon/oci_linux.go
@@ -405,13 +405,7 @@ func getSourceMount(source string) (string, string, error) {
 			idx = i
 		}
 	}
-	// and return it unless it's "/"
-	if mi[idx].Mountpoint != "/" {
-		return mi[idx].Mountpoint, mi[idx].Optional, nil
-	}
-
-	// If we are here, we did not find parent mount. Something is wrong.
-	return "", "", fmt.Errorf("Could not find source mount of %s", source)
+	return mi[idx].Mountpoint, mi[idx].Optional, nil
 }
 
 const (

--- a/components/engine/daemon/oci_linux_test.go
+++ b/components/engine/daemon/oci_linux_test.go
@@ -1,6 +1,7 @@
 package daemon // import "github.com/docker/docker/daemon"
 
 import (
+	"os"
 	"testing"
 
 	containertypes "github.com/docker/docker/api/types/container"
@@ -85,4 +86,17 @@ func TestIpcPrivateVsReadonly(t *testing.T) {
 		}
 		assert.Check(t, is.Equal(false, inSlice(m.Options, "ro")))
 	}
+}
+
+func TestGetSourceMount(t *testing.T) {
+	// must be able to find source mount for /
+	mnt, _, err := getSourceMount("/")
+	assert.NilError(t, err)
+	assert.Equal(t, mnt, "/")
+
+	// must be able to find source mount for current directory
+	cwd, err := os.Getwd()
+	assert.NilError(t, err)
+	_, _, err = getSourceMount(cwd)
+	assert.NilError(t, err)
 }


### PR DESCRIPTION
A recent optimization in getSourceMount() made it return an error
in case when the found mount point is "/". This prevented bind-mounted
volumes from working in such cases.

A (rather trivial but adeqate) unit test case is added.

Fixes: 871c957242 ("getSourceMount(): simplify")
Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>
(cherry picked from commit d8fd6137a1f6d95a2bcdfeb6e1dfa6b816790c5e)