### PR TITLE
[18.03] Fix broken ingress network test

### DIFF
--- a/components/engine/integration/network/service_test.go
+++ b/components/engine/integration/network/service_test.go
@@ -43,7 +43,7 @@ func TestServiceWithPredefinedNetwork(t *testing.T) {
 
 const ingressNet = "ingress"
 
-func TestServiceWithIngressNetwork(t *testing.T) {
+func TestServiceRemoveKeepsIngressNetwork(t *testing.T) {
 	defer setupTest(t)()
 	d := swarm.NewSwarm(t, testEnv)
 	defer d.Stop(t)
@@ -53,9 +53,7 @@ func TestServiceWithIngressNetwork(t *testing.T) {
 	poll.WaitOn(t, swarmIngressReady(client), swarm.NetworkPoll)
 
 	var instances uint64 = 1
-	serviceName := "TestIngressService"
-	serviceSpec := swarmServiceSpec(serviceName, instances)
-	serviceSpec.TaskTemplate.Networks = append(serviceSpec.TaskTemplate.Networks, swarmtypes.NetworkAttachmentConfig{Target: ingressNet})
+	serviceSpec := swarmServiceSpec(t.Name()+"-service", instances)
 	serviceSpec.EndpointSpec = &swarmtypes.EndpointSpec{
 		Ports: []swarmtypes.PortConfig{
 			{


### PR DESCRIPTION
Pulls in the test changes from https://github.com/docker/docker-ce/pull/521/files#diff-0f17629f6eb7610bb6a7aaf765934393L46

This test is broken on the 18.03 branch without this change because services can't attach to the ingress network.