### PR TITLE
[18.03] Add /proc/acpi to masked paths

### DIFF
--- a/components/engine/oci/defaults.go
+++ b/components/engine/oci/defaults.go
@@ -114,6 +114,7 @@ func DefaultLinuxSpec() specs.Spec {
 
 	s.Linux = &specs.Linux{
 		MaskedPaths: []string{
+			"/proc/acpi",
 			"/proc/kcore",
 			"/proc/keys",
 			"/proc/latency_stats",


### PR DESCRIPTION
The deafult OCI linux spec in oci/defaults{_linux}.go in Docker/Moby
from 1.11 to current upstream master does not block /proc/acpi pathnames
allowing attackers to modify host's hardware like enabling/disabling
bluetooth or turning up/down keyboard brightness. SELinux prevents all
of this if enabled.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>
(cherry picked from commit 569b9702a59804617e1cd3611fbbe953e4247b3e)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

Fix for CVE-2018-10892

cherry-pick of https://github.com/moby/moby/pull/37404 for 18.03 (no conflicts)
