### PR TITLE
[18.03] fix bindmount src create race

### DIFF
--- a/components/engine/daemon/volumes.go
+++ b/components/engine/daemon/volumes.go
@@ -228,6 +228,10 @@ func (daemon *Daemon) registerMountPoints(container *container.Container, hostCo
 			}
 		}
 
+		if mp.Type == mounttypes.TypeBind {
+			mp.SkipMountpointCreation = true
+		}
+
 		binds[mp.Destination] = true
 		dereferenceIfExists(mp.Destination)
 		mountPoints[mp.Destination] = mp

--- a/components/engine/volume/volume.go
+++ b/components/engine/volume/volume.go
@@ -123,6 +123,12 @@ type MountPoint struct {
 	// Sepc is a copy of the API request that created this mount.
 	Spec mounttypes.Mount
 
+	// Some bind mounts should not be automatically created.
+	// (Some are auto-created for backwards-compatability)
+	// This is checked on the API but setting this here prevents race conditions.
+	// where a bind dir existed during validation was removed before reaching the setup code.
+	SkipMountpointCreation bool
+
 	// Track usage of this mountpoint
 	// Specifically needed for containers which are running and calls to `docker cp`
 	// because both these actions require mounting the volumes.
@@ -151,6 +157,10 @@ func (m *MountPoint) Cleanup() error {
 // The, optional, checkFun parameter allows doing additional checking
 // before creating the source directory on the host.
 func (m *MountPoint) Setup(mountLabel string, rootIDs idtools.IDPair, checkFun func(m *MountPoint) error) (path string, err error) {
+	if m.SkipMountpointCreation {
+		return m.Source, nil
+	}
+
 	defer func() {
 		if err != nil || !label.RelabelNeeded(m.Mode) {
 			return


### PR DESCRIPTION
Cherry-pick of https://github.com/moby/moby/pull/37378 for 18.03; had to apply manually due to https://github.com/moby/moby/pull/36896 and https://github.com/moby/moby/pull/36637 missing from 18.03 codebase. It's a short and focused fix.

When using the mounts API, bind mounts are not supposed to be
automatically created.

Before this patch there is a race condition between valiating that a
bind path exists and then actually setting up the bind mount where the
bind path may exist during validation but was removed during mountpooint
setup.

This adds a field to the mountpoint struct to ensure that binds created
over the mounts API are not accidentally created.