### PR TITLE
Fix the symlink for docker engine to pick up runc CVE patch

### DIFF
--- a/components/packaging/rpm/centos-7/docker-ce.spec
+++ b/components/packaging/rpm/centos-7/docker-ce.spec
@@ -62,6 +62,7 @@ export DOCKER_GITCOMMIT=%{_gitcommit}
 mkdir -p /go/src/github.com/docker
 rm -f /go/src/github.com/docker/cli
 ln -s /root/rpmbuild/BUILD/src/cli /go/src/github.com/docker/cli
+ln -s /root/rpmbuild/BUILD/src/engine /go/src/github.com/docker/docker
 pushd /go/src/github.com/docker/cli
 make VERSION=%{_origversion} GITCOMMIT=%{_gitcommit} dynbinary manpages # cli
 popd

--- a/components/packaging/rpm/fedora-27/docker-ce.spec
+++ b/components/packaging/rpm/fedora-27/docker-ce.spec
@@ -62,6 +62,7 @@ export DOCKER_GITCOMMIT=%{_gitcommit}
 mkdir -p /go/src/github.com/docker
 rm -f /go/src/github.com/docker/cli
 ln -s /root/rpmbuild/BUILD/src/cli /go/src/github.com/docker/cli
+ln -s /root/rpmbuild/BUILD/src/engine /go/src/github.com/docker/docker
 pushd /go/src/github.com/docker/cli
 make VERSION=%{_origversion} GITCOMMIT=%{_gitcommit} dynbinary manpages # cli
 popd

--- a/components/packaging/rpm/fedora-28/docker-ce.spec
+++ b/components/packaging/rpm/fedora-28/docker-ce.spec
@@ -62,6 +62,7 @@ export DOCKER_GITCOMMIT=%{_gitcommit}
 mkdir -p /go/src/github.com/docker
 rm -f /go/src/github.com/docker/cli
 ln -s /root/rpmbuild/BUILD/src/cli /go/src/github.com/docker/cli
+ln -s /root/rpmbuild/BUILD/src/engine /go/src/github.com/docker/docker
 pushd /go/src/github.com/docker/cli
 make VERSION=%{_origversion} GITCOMMIT=%{_gitcommit} dynbinary manpages # cli
 popd


### PR DESCRIPTION
Fix the issue mentioned in https://github.com/moby/moby/issues/38739#issuecomment-464720902