### PR TITLE
[18.09 Fix link to release notes to be an actual link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 For official release notes for Docker Engine CE and Docker Engine EE, visit the
-[https://docs.docker.com/engine/release-notes/](release notes page).
+[release notes page](https://docs.docker.com/engine/release-notes/).
 
 ## 18.09.3 (2019-02-28)
 


### PR DESCRIPTION
Originally reported here: https://github.com/docker/for-linux/issues/610