### PR TITLE
apparmor: allow readby and tracedby

### DIFF
--- a/components/engine/profiles/apparmor/template.go
+++ b/components/engine/profiles/apparmor/template.go
@@ -44,7 +44,7 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
 
 {{if ge .Version 208095}}
   # suppress ptrace denials when using 'docker ps' or using 'ps' inside a container
-  ptrace (trace,read) peer={{.Name}},
+  ptrace (trace,read,tracedby,readby) peer={{.Name}},
 {{end}}
 }
 `


### PR DESCRIPTION
Fixes audit errors such as:

type=AVC msg=audit(1550236803.810:143):
apparmor="DENIED" operation="ptrace" profile="docker-default"
pid=3181 comm="ps" requested_mask="readby" denied_mask="readby"
peer="docker-default"

audit(1550236375.918:3): apparmor="DENIED" operation="ptrace"
profile="docker-default" pid=2267 comm="ps"
requested_mask="tracedby" denied_mask="tracedby"
peer="docker-default"

Please do not send pull requests to this docker/docker-ce repository.

We do, however, take contributions gladly.

See https://github.com/docker/docker-ce/blob/master/CONTRIBUTING.md

Thanks!
