### PR TITLE
Corrected mistake for the word in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Docker CE
 
-This repository hosts open source components of Docker CE products. The
+This repository host open source components of Docker CE products. The
 `master` branch serves to unify the upstream components on a regular
 basis. Long-lived release branches host the code that goes into a product
 version for the lifetime of the product.


### PR DESCRIPTION
It appears that the singular demonstrative This is modifying the plural noun. Consider using a plural demonstrative or a singular noun instead.

Please do not send pull requests to this docker/docker-ce repository.

We do, however, take contributions gladly.

See https://github.com/docker/docker-ce/blob/master/CONTRIBUTING.md

Thanks!
