### PR TITLE
Correct ImageCreate - platform parameter added

### DIFF
--- a/components/engine/api/swagger.yaml
+++ b/components/engine/api/swagger.yaml
@@ -6238,6 +6238,11 @@ paths:
           in: "header"
           description: "A base64-encoded auth configuration. [See the authentication section for details.](#section/Authentication)"
           type: "string"
+        - name: "platform"
+          in: "query"
+          description: "Platform in the format os[/arch[/variant]]"
+          type: "string"
+          default: ""
       tags: ["Image"]
   /images/{name}/json:
     get:


### PR DESCRIPTION
closes: https://github.com/docker/docker.github.io/issues/9305

> Please do not send pull requests to this docker/docker-ce repository.

The CONTRIBUTINGmd didn't cover patches against older documentation.

Couldn't see how to create a PR against 17.09 in https://github.com/moby/moby

Also needs a fix in 17.10 (API 1.33).

The 17.11 (API 1.34) branch contains the same text so it should be ok.