### PR TITLE
[master] Add a Jenkinsfile to run the CLI Integration tests ENGCORE-1094

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
         buildDiscarder(logRotator(daysToKeepStr: '30'))
         timestamps()
         ansiColor('xterm')
-        timeout(time: 3, unit: 'HOURS')
+        timeout(time: 12, unit: 'HOURS')
     }
     agent {
         node {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,21 @@
+pipeline {
+    options {
+        buildDiscarder(logRotator(daysToKeepStr: '30'))
+        timestamps()
+        ansiColor('xterm')
+        timeout(time: 3, unit: 'HOURS')
+    }
+    agent {
+        node {
+            label 'amd64 && ubuntu-1804 && overlay2'
+        }
+    }
+
+    stages {
+        stage('CLI Integration Test') {
+            steps {
+                sh 'make test-integration-cli'
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a Jenkinsfile setup to run the CLI Integration tests.

I've set this up for amd64 only at the moment and only for the master branch.  Once we've got this working the way we need it to I can submit PRs to backport to other branches.

Signed-off-by: Russell Cardullo <russellcardullo@gmail.com>