### PR TITLE
components: use moby/moby instead of docker/engine

### DIFF
--- a/components.conf
+++ b/components.conf
@@ -2,7 +2,7 @@
 	url = git@github.com:docker/docker-ce-packaging
 	branch = master
 [component "engine"]
-	url = git@github.com:docker/engine
+	url = git@github.com:moby/moby
 	branch = master
 [component "cli"]
 	url = git@github.com:docker/cli


### PR DESCRIPTION
Since it was decided that github.com/moby/moby houses the release branches
of docker engine, maintaining two repos with release branches makes it
error-prone to manage, allowing for backports to slip by and git histories
to be inconsistent.

After this is merged and cherry-picked to other release branches on docker-ce
the plan is to archive the docker/engine repository.

Signed-off-by: Tibor Vass <tibor@docker.com>