### PR TITLE
[19.03] components: use moby/moby instead of docker/engine

### DIFF
--- a/components.conf
+++ b/components.conf
@@ -2,7 +2,7 @@
 	url = git@github.com:docker/docker-ce-packaging
 	branch = 19.03
 [component "engine"]
-	url = git@github.com:docker/engine
+	url = git@github.com:moby/moby
 	branch = 19.03
 [component "cli"]
 	url = git@github.com:docker/cli


### PR DESCRIPTION
Since it was decided that github.com/moby/moby houses the release branches
of docker engine, maintaining two repos with release branches makes it
error-prone to manage, allowing for backports to slip by and git histories
to be inconsistent.

After this is merged and cherry-picked to other release branches on docker-ce
the plan is to archive the docker/engine repository.

Signed-off-by: Tibor Vass <tibor@docker.com>
(cherry picked from commit 24188c2)
Signed-off-by: Tibor Vass <tibor@docker.com>

Cherry-pick of https://github.com/docker/docker-ce/pull/641