### PR TITLE
seccomp: allow 'rseq' syscall in default seccomp profile

### DIFF
--- a/components/engine/profiles/seccomp/seccomp_default.go
+++ b/components/engine/profiles/seccomp/seccomp_default.go
@@ -254,6 +254,7 @@ func DefaultProfile() *types.Seccomp {
 				"renameat",
 				"renameat2",
 				"restart_syscall",
+				"rseq",
 				"rmdir",
 				"rt_sigaction",
 				"rt_sigpending",


### PR DESCRIPTION
Restartable Sequences (rseq) are a kernel-based mechanism for fast
update operations on per-core data in user-space. Some libraries, like
the newest version of Google's TCMalloc depend on it [1].

This also makes dockers default seccomp profile on par with systemd's,
which enabled 'rseq' in early 2019 [2].

1: https://google.github.io/tcmalloc/design.html
2: https://github.com/systemd/systemd/pull/12133/commits/6fee3be0b4929d5641bf1c850fce7884b6d1e44e