### PR TITLE
docker man page: clarify /etc/docker/daemon.json may not exist or empty

### DIFF
--- a/components/cli/docs/reference/commandline/dockerd.md
+++ b/components/cli/docs/reference/commandline/dockerd.md
@@ -30,7 +30,7 @@ Options:
       --bip string                            Specify network bridge IP
   -b, --bridge string                         Attach containers to a network bridge
       --cgroup-parent string                  Set parent cgroup for all containers
-      --config-file string                    Daemon configuration file (default "/etc/docker/daemon.json")
+      --config-file string                    Daemon configuration file (default "/etc/docker/daemon.json", may not exist or be empty)
       --containerd string                     containerd grpc address
       --containerd-namespace string           Containerd namespace to use (default "moby")
       --containerd-plugins-namespace string   Containerd namespace to use for plugins (default "plugins.moby")


### PR DESCRIPTION
It is confusing:  Dockers documentation says you have to CHANGE a flag in that file, although it does not exist.

I know, I shouldn't send pull requests to this docker/docker-ce repository, but acccording  https://github.com/docker/docker-ce/blob/master/CONTRIBUTING.md
I should report it to https://github.com/moby/moby, but I don't find the code there